### PR TITLE
fix: update registry provider address

### DIFF
--- a/main.go
+++ b/main.go
@@ -18,7 +18,7 @@ var version string = "dev"
 
 func main() {
 	err := providerserver.Serve(context.Background(), readme.New(version), providerserver.ServeOpts{
-		Address: "github.com/liveoaklabs/readme",
+		Address: "registry.terraform.io/liveoaklabs/readme",
 		// This provider requires Terraform 1.0+
 		ProtocolVersion: 6,
 	})


### PR DESCRIPTION
Update the address to use `registry.terraform.io` instead of the development address.

https://developer.hashicorp.com/terraform/tutorials/providers-plugin-framework/providers-plugin-framework-provider#implement-the-provider-server