### PR TITLE
fix: re-create deleted resources

### DIFF
--- a/readme/api_specification_resource.go
+++ b/readme/api_specification_resource.go
@@ -273,6 +273,12 @@ func (r *apiSpecificationResource) Read(
 	if state.UUID.ValueString() != "" {
 		def, apiResponse, err := r.client.APIRegistry.Get(state.UUID.ValueString())
 		if err != nil {
+			if apiResponse.APIErrorResponse.Error == "SPEC_NOTFOUND" {
+				resp.State.RemoveResource(ctx)
+
+				return
+			}
+
 			resp.Diagnostics.AddError(
 				"Unable to read API specification.",
 				clientError(err, apiResponse),

--- a/readme/doc.go
+++ b/readme/doc.go
@@ -117,13 +117,13 @@ func getDoc(
 	slug string,
 	model docModel,
 	options readme.RequestOptions,
-) (docModel, error) {
+) (docModel, *readme.APIResponse, error) {
 	var state docModel
 
 	// Get the doc from ReadMe.
 	response, apiResponse, err := client.Doc.Get(slug, options)
 	if err != nil {
-		return state, fmt.Errorf(clientError(err, apiResponse))
+		return state, apiResponse, fmt.Errorf(clientError(err, apiResponse))
 	}
 
 	// Map the API object to the Terraform model.
@@ -152,7 +152,7 @@ func getDoc(
 			options,
 		)
 		if err != nil {
-			return state, errors.New(clientError(err, apiResponse))
+			return state, apiResponse, errors.New(clientError(err, apiResponse))
 		}
 		state.CategorySlug = types.StringValue(category.Slug)
 	}
@@ -171,13 +171,13 @@ func getDoc(
 			parent, apiResponse, err := client.Doc.Get("id:"+state.ParentDoc.ValueString(), options)
 			if err != nil {
 				// failing here
-				return state, errors.New(clientError(err, apiResponse))
+				return state, apiResponse, errors.New(clientError(err, apiResponse))
 			}
 			state.ParentDocSlug = types.StringValue(parent.Slug)
 		}
 	}
 
-	return state, nil
+	return state, apiResponse, nil
 }
 
 // docModelAlgoliaValue returns the populated `algolia` object value embedded within `docModel`.

--- a/readme/doc_data_source.go
+++ b/readme/doc_data_source.go
@@ -55,7 +55,7 @@ func (d *docDataSource) Read(
 	tflog.Info(ctx, fmt.Sprintf("retrieving doc with request options=%+v", requestOpts))
 
 	// Get the doc.
-	state, err := getDoc(d.client, ctx, state.Slug.ValueString(), state, requestOpts)
+	state, _, err := getDoc(d.client, ctx, state.Slug.ValueString(), state, requestOpts)
 	if err != nil {
 		resp.Diagnostics.AddError("Unable to retrieve doc metadata.", err.Error())
 

--- a/readme/doc_resource.go
+++ b/readme/doc_resource.go
@@ -159,7 +159,7 @@ func (r *docResource) Create(
 	}
 
 	// Get the doc.
-	state, err = getDoc(r.client, ctx, response.Slug, plan, requestOpts)
+	state, _, err = getDoc(r.client, ctx, response.Slug, plan, requestOpts)
 	if err != nil {
 		resp.Diagnostics.AddError(
 			"Unable to create doc.",
@@ -202,8 +202,14 @@ func (r *docResource) Read(
 	tflog.Info(ctx, fmt.Sprintf("retrieving doc with request options=%+v", requestOpts))
 
 	// Get the doc.
-	state, err := getDoc(r.client, ctx, state.Slug.ValueString(), plan, requestOpts)
+	state, apiResponse, err := getDoc(r.client, ctx, state.Slug.ValueString(), plan, requestOpts)
 	if err != nil {
+		if apiResponse.APIErrorResponse.Error == "DOC_NOTFOUND" {
+			resp.State.RemoveResource(ctx)
+
+			return
+		}
+
 		resp.Diagnostics.AddError("Unable to read doc.", err.Error())
 
 		return
@@ -259,7 +265,7 @@ func (r *docResource) Update(
 	}
 
 	// Get the doc.
-	plan, err = getDoc(r.client, ctx, response.Slug, plan, requestOpts)
+	plan, _, err = getDoc(r.client, ctx, response.Slug, plan, requestOpts)
 	if err != nil {
 		resp.Diagnostics.AddError(
 			"Unable to update doc.",


### PR DESCRIPTION
This fixes the resources to create a new resource when the API responds with a "NOTFOUND" message when reading a resource that exists in the state - resources that were created by Terraform and then deleted outside of Terraform.

Prior to this the provider would return an error that the resource didn't exist, requiring a manual removal from the state.