### PR TITLE
feat: API spec data source filtering

### DIFF
--- a/docs/data-sources/api_specification.md
+++ b/docs/data-sources/api_specification.md
@@ -4,14 +4,14 @@ page_title: "readme_api_specification Data Source - readme"
 subcategory: ""
 description: |-
   Retrieve metadata about an API specification on ReadMe.com
-  See https://docs.readme.com/main/reference/getapispecification for more information about this API endpoint.
+  An ID or title must be specified to retrieve an API specification. The filter attribute may be used to filter API specifications by category ID, category slug, category title, or whether or not the API specification has a category. See https://docs.readme.com/main/reference/getapispecification for more information about this API endpoint.
 ---
 
 # readme_api_specification (Data Source)
 
 Retrieve metadata about an API specification on ReadMe.com
 
-See <https://docs.readme.com/main/reference/getapispecification> for more information about this API endpoint.
+An ID or title must be specified to retrieve an API specification. The `filter` attribute may be used to filter API specifications by category ID, category slug, category title, or whether or not the API specification has a category. See <https://docs.readme.com/main/reference/getapispecification> for more information about this API endpoint.
 
 ## Example Usage
 
@@ -35,6 +35,7 @@ output "api_spec_data_lookup" {
 
 ### Optional
 
+- `filter` (Attributes) Filter API specifications by the specified criteria. (see [below for nested schema](#nestedatt--filter))
 - `id` (String) The unique identifier of the API specification.
 - `title` (String) The title of the API specification derived from the specification JSON.
 
@@ -45,6 +46,17 @@ output "api_spec_data_lookup" {
 - `source` (String) The creation source of the API specification.
 - `type` (String) The type of the API specification.
 - `version` (String) The version of the API specification.
+
+<a id="nestedatt--filter"></a>
+### Nested Schema for `filter`
+
+Optional:
+
+- `category_id` (String) Return only API specifications with the specified category ID.
+- `category_slug` (String) Return only API specifications with the specified category slug.
+- `category_title` (String) Return only API specifications with the specified category title.
+- `has_category` (Boolean) Return only API specifications with a category.
+
 
 <a id="nestedatt--category"></a>
 ### Nested Schema for `category`

--- a/readme/api_specification_data_source_test.go
+++ b/readme/api_specification_data_source_test.go
@@ -1,6 +1,7 @@
 package readme
 
 import (
+	"regexp"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
@@ -9,82 +10,270 @@ import (
 
 func TestAPISpecificationDataSource(t *testing.T) {
 	defer gock.Off()
+
+	// Mock the common API response.
+	testResponse := `[{
+		"id": "6398a4a594b26e00885e7ec0",
+		"lastSynced": "2022-12-13T16:39:39.512Z",
+		"category": {
+			"id": "63f8dc63d70452003b73ff12",
+			"title": "Test API Spec",
+			"slug": "test-api-spec"
+		},
+		"source": "api",
+		"title": "Test API Spec",
+		"type": "oas",
+		"version": "638cf4cfdea3ff0096d1a95a"
+	}]`
+
 	testCases := []struct {
-		name   string
-		config string
+		name        string
+		config      string
+		expectError string
+		response    string
 	}{
+		// Unfiltered tests by ID or title.
 		{
-			name:   "lookup api specification by id",
+			name:   "it should return an API spec when a matching ID is found",
 			config: `data "readme_api_specification" "test" { id = "6398a4a594b26e00885e7ec0" }`,
 		},
 		{
-			name:   "lookup api specification by title",
+			name:   "it should return an API spec when a matching title is found",
 			config: `data "readme_api_specification" "test" { title = "Test API Spec" }`,
+		},
+		{
+			name: "it should return an API spec when both a matching ID and title are found",
+			config: `data "readme_api_specification" "test" {
+				id    = "6398a4a594b26e00885e7ec0"
+				title = "Test API Spec"
+			}`,
+		},
+
+		// Filter tests.
+		{
+			name: "it should return an API spec when a matching title and category ID is found",
+			config: `data "readme_api_specification" "test" {
+				title  = "Test API Spec"
+				filter = { category_id = "63f8dc63d70452003b73ff12" }
+			}`,
+		},
+		{
+			name: "it should return an API spec when a matching title and category title is found",
+			config: `data "readme_api_specification" "test" {
+				title  = "Test API Spec"
+				filter = { category_title = "Test API Spec" }
+			}`,
+		},
+		{
+			name: "it should return an API spec when a matching title and category slug is found",
+			config: `data "readme_api_specification" "test" {
+				title  = "Test API Spec"
+				filter = { category_slug = "test-api-spec" }
+			}`,
+		},
+		{
+			name: "it should return an API spec when a matching title, category ID, and category title is found",
+			config: `data "readme_api_specification" "test" {
+				title  = "Test API Spec"
+				filter = {
+					category_id    = "63f8dc63d70452003b73ff12"
+					category_title = "Test API Spec"
+				}
+			}`,
+		},
+		{
+			name: "it should return an API spec when a matching title, category ID, and category slug is found",
+			config: `data "readme_api_specification" "test" {
+				title  = "Test API Spec"
+				filter = {
+					category_id  = "63f8dc63d70452003b73ff12"
+					category_slug = "test-api-spec"
+				}
+			}`,
+		},
+		{
+			name: "it should return an API spec when a matching id and category_id is found",
+			config: `data "readme_api_specification" "test" {
+				id     = "6398a4a594b26e00885e7ec0"
+				filter = { category_id = "63f8dc63d70452003b73ff12" }
+			}`,
+		},
+		{
+			name: "it should return an API spec when a matching id and category_title is found",
+			config: `data "readme_api_specification" "test" {
+				id     = "6398a4a594b26e00885e7ec0"
+				filter = { category_title = "Test API Spec" }
+			}`,
+		},
+		{
+			name: "it should return an API spec when a matching id and category_slug is found",
+			config: `data "readme_api_specification" "test" {
+				id     = "6398a4a594b26e00885e7ec0"
+				filter = { category_slug = "test-api-spec" }
+			}`,
+		},
+
+		// Negative tests
+		{
+			name:        "it should return an error when no ID or title is provided",
+			config:      `data "readme_api_specification" "test" { }`,
+			expectError: "An ID or title must be specified to retrieve an API specification.",
+		},
+		{
+			name:        "it should return an error when no API specs exist in a project",
+			config:      `data "readme_api_specification" "test" { title = "Test API Spec" }`,
+			expectError: "No API specifications were found in the ReadMe project",
+			response:    `[]`,
+		},
+		{
+			name: "it should return an error when no matching ID is found",
+			config: `data "readme_api_specification" "test" {
+				id = "does-not-exist"
+			}`,
+			expectError: "API specification not found",
+		},
+		{
+			name: "it should return an error when no matching title is found",
+			config: `data "readme_api_specification" "test" {
+				title = "does-not-exist"
+			}`,
+			expectError: "Unable to find API specification with title: does-not-exist",
+		},
+		{
+			name: "it should return an error when no matching ID and category slug is found",
+			config: `data "readme_api_specification" "test" {
+				id = "6398a4a594b26e00885e7ec0"
+				filter = { category_slug = "does-not-exist" }
+			}`,
+			expectError: "Unable to find API specification with the specified criteria.",
+		},
+		{
+			name: "it should return an error when no matching title and category slug is found",
+			config: `data "readme_api_specification" "test" {
+				title = "Test API Spec"
+				filter = { category_slug = "does-not-exist" }
+			}`,
+			expectError: "Unable to find API specification with title: Test API Spec",
+		},
+		{
+			name: "it should return an error when no matching title and category id is found",
+			config: `data "readme_api_specification" "test" {
+				title = "Test API Spec"
+				filter = { category_id = "does-not-exist" }
+			}`,
+			expectError: "Unable to find API specification with title: Test API Spec",
+		},
+		{
+			name: "it should return an error when no matching title and category title is found",
+			config: `data "readme_api_specification" "test" {
+				title = "Test API Spec"
+				filter = { category_title = "does-not-exist" }
+			}`,
+			expectError: "Unable to find API specification with title: Test API Spec",
+		},
+		{
+			name: "it should return an error when no matching title with a category is found",
+			config: `data "readme_api_specification" "test" {
+				title = "Test API Spec"
+				filter = { has_category = true }
+			}`,
+			response: `[{
+				"id": "6398a4a594b26e00885e7ec0",
+				"lastSynced": "2022-12-13T16:39:39.512Z",
+				"category": null,
+				"source": "api",
+				"title": "Test API Spec",
+				"type": "oas",
+				"version": "638cf4cfdea3ff0096d1a95a"
+			}]`,
+			expectError: "Unable to find API specification with title: Test API Spec",
 		},
 	}
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			resource.Test(t, resource.TestCase{
-				IsUnitTest:               true,
-				ProtoV6ProviderFactories: testProtoV6ProviderFactories,
-				Steps: []resource.TestStep{
-					{
-						Config: providerConfig + tc.config,
-						Check: resource.ComposeAggregateTestCheckFunc(
-							resource.TestCheckResourceAttr(
-								"data.readme_api_specification.test",
-								"id",
-								"6398a4a594b26e00885e7ec0",
-							),
-							resource.TestCheckResourceAttr(
-								"data.readme_api_specification.test",
-								"last_synced",
-								"2022-12-13T16:39:39.512Z",
-							),
-							resource.TestCheckResourceAttr(
-								"data.readme_api_specification.test",
-								"source",
-								"api",
-							),
-							resource.TestCheckResourceAttr(
-								"data.readme_api_specification.test",
-								"title",
-								"Test API Spec",
-							),
-							resource.TestCheckResourceAttr(
-								"data.readme_api_specification.test",
-								"type",
-								"oas",
-							),
-							resource.TestCheckResourceAttr(
-								"data.readme_api_specification.test",
-								"version",
-								"638cf4cfdea3ff0096d1a95a",
-							),
-						),
-						PreConfig: func() {
-							gock.OffAll()
-							gock.New(testURL).
-								Get("/api-specification").
-								MatchParam("perPage", "100").
-								MatchParam("page", "1").
-								Persist().
-								Reply(200).
-								SetHeaders(map[string]string{"link": `<>; rel="next", <>; rel="prev", <>; rel="last"`}).
-								JSON(`[{
-									"id": "6398a4a594b26e00885e7ec0",
-									"lastSynced": "2022-12-13T16:39:39.512Z",
-									"source": "api",
-									"title": "Test API Spec",
-									"type": "oas",
-									"version": "638cf4cfdea3ff0096d1a95a"
-								}]
-							`)
+			response := testResponse
+			if tc.response != "" {
+				response = tc.response
+			}
+
+			if tc.expectError != "" {
+				resource.Test(t, resource.TestCase{
+					IsUnitTest:               true,
+					ProtoV6ProviderFactories: testProtoV6ProviderFactories,
+					Steps: []resource.TestStep{
+						{
+							Config:      providerConfig + tc.config,
+							ExpectError: regexp.MustCompile(tc.expectError),
+							PreConfig: func() {
+								gock.OffAll()
+								gock.New(testURL).
+									Get("/api-specification").
+									MatchParam("perPage", "100").
+									MatchParam("page", "1").
+									Persist().
+									Reply(200).
+									SetHeaders(map[string]string{"link": `<>; rel="next", <>; rel="prev", <>; rel="last"`}).
+									JSON(response)
+							},
 						},
 					},
-				},
-			})
+				})
+
+			} else {
+				resource.Test(t, resource.TestCase{
+					IsUnitTest:               true,
+					ProtoV6ProviderFactories: testProtoV6ProviderFactories,
+					Steps: []resource.TestStep{
+						{
+							Config: providerConfig + tc.config,
+							Check: resource.ComposeAggregateTestCheckFunc(
+								resource.TestCheckResourceAttr(
+									"data.readme_api_specification.test",
+									"id",
+									"6398a4a594b26e00885e7ec0",
+								),
+								resource.TestCheckResourceAttr(
+									"data.readme_api_specification.test",
+									"last_synced",
+									"2022-12-13T16:39:39.512Z",
+								),
+								resource.TestCheckResourceAttr(
+									"data.readme_api_specification.test",
+									"source",
+									"api",
+								),
+								resource.TestCheckResourceAttr(
+									"data.readme_api_specification.test",
+									"title",
+									"Test API Spec",
+								),
+								resource.TestCheckResourceAttr(
+									"data.readme_api_specification.test",
+									"type",
+									"oas",
+								),
+								resource.TestCheckResourceAttr(
+									"data.readme_api_specification.test",
+									"version",
+									"638cf4cfdea3ff0096d1a95a",
+								),
+							),
+							PreConfig: func() {
+								gock.OffAll()
+								gock.New(testURL).
+									Get("/api-specification").
+									MatchParam("perPage", "100").
+									MatchParam("page", "1").
+									Persist().
+									Reply(200).
+									SetHeaders(map[string]string{"link": `<>; rel="next", <>; rel="prev", <>; rel="last"`}).
+									JSON(response)
+							},
+						},
+					},
+				})
+			}
 		})
 	}
 }


### PR DESCRIPTION
Add a `filter` attribute to the `readme_api_specification` data source that can be used to apply filtering to the query to retrieve an API specification.

An `id` or `title` is still required, but `filter` can be used to set additional criteria, particularly around the category an API specification exists within.