### PR TITLE
fix: Trim leading/trailing whitespace from docs

### DIFF
--- a/docs/data-sources/doc.md
+++ b/docs/data-sources/doc.md
@@ -39,7 +39,8 @@ output "example_doc" {
 
 - `algolia` (Attributes) Metadata about the Algolia search integration. See <https://docs.readme.com/main/docs/search> for more information. (see [below for nested schema](#nestedatt--algolia))
 - `api` (Attributes) Metadata for an API doc. (see [below for nested schema](#nestedatt--api))
-- `body` (String) The body content of the doc, formatted in ReadMe or GitHub flavored Markdown. Accepts long page content, for example, greater than 100k characters.
+- `body` (String) The body content of the doc, formatted in ReadMe or GitHub flavored Markdown.
+- `body_clean` (String) The body content of the doc, formatted in ReadMe or GitHub flavored Markdown. This is an alias for the `body` attribute.
 - `body_html` (String) The body content in HTML.
 - `category` (String) The category ID of the doc. Note that changing the category will result in a replacement of the doc resource.
 - `category_slug` (String) **Required**. The category ID of the doc. Note that changing the category will result in a replacement of the doc resource. This attribute may optionally be set in the body front matter.

--- a/docs/resources/doc.md
+++ b/docs/resources/doc.md
@@ -43,10 +43,8 @@ resource "readme_doc" "example" {
     # type can be specified as an attribute or in the body front matter.
     type = "basic"
 
-    # body can be read from a file using Terraform's `file()` function.
-    # For best results, wrap the string with the `chomp()` function to remove
-    # trailing newlines. ReadMe's API trims these implicitly.
-    body = chomp(file("mydoc.md"))
+    # body can be read from a file using Terraform's `file()` or `templatefile()` functions.
+    body = file("mydoc.md")
 }
 ```
 
@@ -76,6 +74,7 @@ Docs that specify a `parent_doc` or `parent_doc_slug` will use their parent's ca
 
 - `algolia` (Attributes) Metadata about the Algolia search integration. See <https://docs.readme.com/main/docs/search> for more information. (see [below for nested schema](#nestedatt--algolia))
 - `api` (Attributes) Metadata for an API doc. (see [below for nested schema](#nestedatt--api))
+- `body_clean` (String) The body content of the doc after transformations such as trimming leading and trailingspaces.
 - `body_html` (String) The body content in HTML.
 - `created_at` (String) Timestamp of when the version was created.
 - `deprecated` (Boolean) Toggles if a doc is deprecated or not.

--- a/examples/resources/readme_doc/resource.tf
+++ b/examples/resources/readme_doc/resource.tf
@@ -19,8 +19,6 @@ resource "readme_doc" "example" {
     # type can be specified as an attribute or in the body front matter.
     type = "basic"
 
-    # body can be read from a file using Terraform's `file()` function.
-    # For best results, wrap the string with the `chomp()` function to remove
-    # trailing newlines. ReadMe's API trims these implicitly.
-    body = chomp(file("mydoc.md"))
+    # body can be read from a file using Terraform's `file()` or `templatefile()` functions.
+    body = file("mydoc.md")
 }

--- a/readme/doc.go
+++ b/readme/doc.go
@@ -17,6 +17,7 @@ type docModel struct {
 	Algolia         types.Object `tfsdk:"algolia"`
 	API             types.Object `tfsdk:"api"`
 	Body            types.String `tfsdk:"body"`
+	BodyClean       types.String `tfsdk:"body_clean"`
 	BodyHTML        types.String `tfsdk:"body_html"`
 	Category        types.String `tfsdk:"category"`
 	CategorySlug    types.String `tfsdk:"category_slug"`
@@ -68,7 +69,8 @@ func docModelValue(ctx context.Context, doc readme.Doc, model docModel) docModel
 	return docModel{
 		Algolia:         docModelAlgoliaValue(doc.Algolia),
 		API:             docModelAPIValue(doc.API),
-		Body:            types.StringValue(doc.Body),
+		Body:            model.Body,
+		BodyClean:       types.StringValue(doc.Body),
 		BodyHTML:        types.StringValue(doc.BodyHTML),
 		Category:        types.StringValue(doc.Category),
 		CategorySlug:    model.CategorySlug,

--- a/readme/doc_data_source.go
+++ b/readme/doc_data_source.go
@@ -62,6 +62,8 @@ func (d *docDataSource) Read(
 		return
 	}
 
+	state.Body = state.BodyClean
+
 	// Set state.
 	diags = resp.State.Set(ctx, &state)
 	resp.Diagnostics.Append(diags...)
@@ -204,8 +206,12 @@ func (d *docDataSource) Schema(
 				},
 			},
 			"body": schema.StringAttribute{
+				Description: "The body content of the doc, formatted in ReadMe or GitHub flavored Markdown.",
+				Computed:    true,
+			},
+			"body_clean": schema.StringAttribute{
 				Description: "The body content of the doc, formatted in ReadMe or GitHub flavored Markdown. " +
-					"Accepts long page content, for example, greater than 100k characters.",
+					"This is an alias for the `body` attribute.",
 				Computed: true,
 			},
 			"body_html": schema.StringAttribute{

--- a/readme/doc_resource.go
+++ b/readme/doc_resource.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"reflect"
+	"strings"
 
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
@@ -112,7 +113,7 @@ func (r docResource) ValidateConfig(
 // docPlanToParams maps plan attributes to a `readme.DocParams` struct to create or update a doc.
 func docPlanToParams(ctx context.Context, plan docModel) readme.DocParams {
 	params := readme.DocParams{
-		Body:   plan.Body.ValueString(),
+		Body:   strings.TrimSpace(plan.Body.ValueString()),
 		Hidden: plan.Hidden.ValueBoolPointer(),
 		Order:  intPoint(int(plan.Order.ValueInt64())),
 		Title:  plan.Title.ValueString(),
@@ -247,8 +248,7 @@ func (r *docResource) Update(
 	resp *resource.UpdateResponse,
 ) {
 	// Retrieve values from plan and current state.
-	var config, plan, state docModel
-	resp.Diagnostics.Append(req.State.Get(ctx, &config)...)
+	var plan, state docModel
 	resp.Diagnostics.Append(req.State.Get(ctx, &state)...)
 	resp.Diagnostics.Append(req.Plan.Get(ctx, &plan)...)
 	if resp.Diagnostics.HasError() {
@@ -497,6 +497,11 @@ func (r *docResource) Schema(
 					"Accepts long page content, for example, greater than 100k characters.",
 				Computed: true,
 				Optional: true,
+			},
+			"body_clean": schema.StringAttribute{
+				Description: "The body content of the doc after transformations such as trimming leading and trailing" +
+					"spaces.",
+				Computed: true,
 			},
 			"body_html": schema.StringAttribute{
 				Description: "The body content in HTML.",

--- a/readme/doc_resource_test.go
+++ b/readme/doc_resource_test.go
@@ -27,7 +27,7 @@ func TestDocResource(t *testing.T) {
 						category = "%s"
 						type     = "%s"
 					}`,
-					mockDoc.Title, mockDoc.Body, mockDoc.Category, mockDoc.Type,
+					mockDoc.Title, mockDocBodyString, mockDoc.Category, mockDoc.Type,
 				),
 				PreConfig: func() {
 					docCommonGocks()
@@ -48,7 +48,7 @@ func TestDocResource(t *testing.T) {
 						category = "%s"
 						type     = "%s"
 					}`,
-					mockDoc.Title, mockDoc.Body, mockDoc.Category, mockDoc.Type,
+					mockDoc.Title, mockDocBodyString, mockDoc.Category, mockDoc.Type,
 				),
 				PreConfig: func() {
 					gock.OffAll()
@@ -76,7 +76,7 @@ func TestDocResource(t *testing.T) {
 						category = "%s"
 						type     = "%s"
 					}`,
-					mockDoc.Body, mockDoc.Category, mockDoc.Type,
+					mockDocBodyString, mockDoc.Category, mockDoc.Type,
 				),
 				PreConfig: func() {
 					gock.OffAll()
@@ -94,7 +94,7 @@ func TestDocResource(t *testing.T) {
 						category = "%s"
 						type     = "%s"
 					}`,
-					mockDoc.Body, mockDoc.Category, mockDoc.Type,
+					mockDocBodyString, mockDoc.Category, mockDoc.Type,
 				),
 				PreConfig: func() {
 					gock.OffAll()
@@ -123,7 +123,7 @@ func TestDocResource(t *testing.T) {
 						category = "%s"
 						type     = "%s"
 					}`,
-					mockDoc.Body, mockDoc.Category, mockDoc.Type,
+					mockDocBodyString, mockDoc.Category, mockDoc.Type,
 				),
 				PreConfig: func() {
 					gock.OffAll()
@@ -151,7 +151,7 @@ func TestDocResource(t *testing.T) {
 						category = "%s"
 						type     = "%s"
 					}`,
-					mockDoc.Title, mockDoc.Body, mockDoc.Category, mockDoc.Type,
+					mockDoc.Title, mockDocBodyString, mockDoc.Category, mockDoc.Type,
 				),
 				PreConfig: func() {
 					gock.OffAll()
@@ -171,7 +171,7 @@ func TestDocResource(t *testing.T) {
 						category = "%s"
 						type     = "%s"
 					}`,
-					mockDoc.Body, mockDoc.Category, mockDoc.Type,
+					mockDocBodyString, mockDoc.Category, mockDoc.Type,
 				),
 				PreConfig: func() {
 					gock.OffAll()

--- a/readme/doc_test.go
+++ b/readme/doc_test.go
@@ -105,6 +105,9 @@ var mockDoc readme.Doc = readme.Doc{
 	Version:       mockVersion.ID,
 }
 
+// mockDocBodyString represents a "raw" body string provided in the configuration with extraneous whitespace.
+var mockDocBodyString string = fmt.Sprintf(`  \n%s\n\n `, mockDoc.Body)
+
 // makeMockDocParent returns a doc for use as a 'parent' doc.
 func makeMockDocParent() readme.Doc {
 	parentDoc := mockDoc
@@ -196,6 +199,9 @@ func docCommonGocks() {
 
 // docResourceCommonChecks returns all attribute checks for the data source and resource.
 func docResourceCommonChecks(mock readme.Doc, prefix string) resource.TestCheckFunc {
+	if prefix == "data." {
+		mockDocBodyString = mockDoc.Body
+	}
 	return resource.ComposeAggregateTestCheckFunc(
 		resource.TestCheckResourceAttr(
 			prefix+"readme_doc.test",
@@ -280,7 +286,8 @@ func docResourceCommonChecks(mock readme.Doc, prefix string) resource.TestCheckF
 			fmt.Sprintf("%v", mock.API.Results.Codes[0].Status),
 		),
 		resource.TestCheckResourceAttr(prefix+"readme_doc.test", "api.url", mock.API.URL),
-		resource.TestCheckResourceAttr(prefix+"readme_doc.test", "body", mock.Body),
+		resource.TestCheckResourceAttr(prefix+"readme_doc.test", "body", mockDocBodyString),
+		resource.TestCheckResourceAttr(prefix+"readme_doc.test", "body_clean", mock.Body),
 		resource.TestCheckResourceAttr(prefix+"readme_doc.test", "body_html", mock.BodyHTML),
 		resource.TestCheckResourceAttr(prefix+"readme_doc.test", "category", mock.Category),
 		resource.TestCheckResourceAttr(prefix+"readme_doc.test", "created_at", mock.CreatedAt),


### PR DESCRIPTION
The ReadMe API removes leading and trailing whitespace from docs upon upload. Prior to this commit, the provider would produce a warning about "inconsistent results after applying" if `chomp()` and `trimspace()` weren't used.

This adds a `body_clean` read-only attribute to the doc resource and data source that represents the body string as synchronized with readme. The existing `body` attribute cannot be changed, since it's a configurable value.