### PR TITLE
ci: run check-vuln independent of gosec

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -21,6 +21,7 @@ jobs:
       - uses: actions/setup-go@fac708d6674e30b6ba41289acaab6d4b75aa0753 # v4.0.1
         with:
           go-version-file: 'go.mod'
+          check-latest: true
       - run: go mod download
       - run: go build -v .
 
@@ -31,6 +32,7 @@ jobs:
       - uses: actions/setup-go@fac708d6674e30b6ba41289acaab6d4b75aa0753 # v4.0.1
         with:
           go-version-file: 'go.mod'
+          check-latest: true
       - run: go generate ./...
       - name: git diff
         run: |
@@ -45,6 +47,7 @@ jobs:
       - uses: actions/setup-go@fac708d6674e30b6ba41289acaab6d4b75aa0753 # v4.0.1
         with:
           go-version-file: 'go.mod'
+          check-latest: true
 
       - name: check-vuln
         run: make check-vuln
@@ -63,6 +66,7 @@ jobs:
       - uses: actions/setup-go@fac708d6674e30b6ba41289acaab6d4b75aa0753 # v4.0.1
         with:
           go-version-file: 'go.mod'
+          check-latest: true
 
       - name: Lint
         run: make lint
@@ -85,6 +89,7 @@ jobs:
       - uses: actions/setup-go@fac708d6674e30b6ba41289acaab6d4b75aa0753 # v4.0.1
         with:
           go-version-file: 'go.mod'
+          check-latest: true
 
       - name: Test
         run: make coverage

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -21,7 +21,6 @@ jobs:
       - uses: actions/setup-go@fac708d6674e30b6ba41289acaab6d4b75aa0753 # v4.0.1
         with:
           go-version-file: 'go.mod'
-          cache: true
       - run: go mod download
       - run: go build -v .
 
@@ -32,7 +31,6 @@ jobs:
       - uses: actions/setup-go@fac708d6674e30b6ba41289acaab6d4b75aa0753 # v4.0.1
         with:
           go-version-file: 'go.mod'
-          cache: true
       - run: go generate ./...
       - name: git diff
         run: |
@@ -47,7 +45,6 @@ jobs:
       - uses: actions/setup-go@fac708d6674e30b6ba41289acaab6d4b75aa0753 # v4.0.1
         with:
           go-version-file: 'go.mod'
-          cache: true
 
       - name: check-vuln
         run: make check-vuln
@@ -66,7 +63,6 @@ jobs:
       - uses: actions/setup-go@fac708d6674e30b6ba41289acaab6d4b75aa0753 # v4.0.1
         with:
           go-version-file: 'go.mod'
-          cache: true
 
       - name: Lint
         run: make lint
@@ -89,7 +85,6 @@ jobs:
       - uses: actions/setup-go@fac708d6674e30b6ba41289acaab6d4b75aa0753 # v4.0.1
         with:
           go-version-file: 'go.mod'
-          cache: true
 
       - name: Test
         run: make coverage

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -49,15 +49,15 @@ jobs:
           go-version-file: 'go.mod'
           cache: true
 
+      - name: check-vuln
+        run: make check-vuln
+
       - name: gosec
         uses: securego/gosec@v2.16.0
         env:
           GO111MODULE: on
         with:
           args: ./...
-
-      - name: check-vuln
-        run: make check-vuln
 
   lint:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Move the 'check-vuln' step to run in the "setup-go" context, which uses a more current version of Go than 'gosec' and the same version we're building with. This has caused 'check-vuln' to fail several times in the past due to the lag between 'gosec' and upstream Go releases.