### PR TITLE
Fix delete api spec

### DIFF
--- a/docs/resources/api_specification.md
+++ b/docs/resources/api_specification.md
@@ -35,6 +35,11 @@ See <https://docs.readme.com/main/reference/uploadapispecification> for more inf
 resource "readme_api_specification" "example" {
   # 'definition' accepts a string of an OpenAPI specification definition JSON.
   definition = file("petstore.json")
+
+  # When an API specification is created, a category is also created but is
+  # not deleted when the API specification is deleted. Set this parameter to
+  # true to delete the category when the API specification is deleted.
+  delete_category = true
 }
 
 # Output the ID of the created resource.
@@ -57,6 +62,7 @@ output "created_spec_json" {
 
 ### Optional
 
+- `delete_category` (Boolean) Delete the category associated with the API specification when the resource is deleted.
 - `semver` (String) The semver(-ish) of the API specification. This value may also be set in the definition JSON `info:version` key, but will be ignored if this attribute is set. Changing the version of a created resource will replace the API specification. Use unique resources to use the same specification across multiple versions.
 
 Learn more about document versioning at <https://docs.readme.com/main/docs/versions>.

--- a/examples/resources/readme_api_specification/resource.tf
+++ b/examples/resources/readme_api_specification/resource.tf
@@ -2,6 +2,11 @@
 resource "readme_api_specification" "example" {
   # 'definition' accepts a string of an OpenAPI specification definition JSON.
   definition = file("petstore.json")
+
+  # When an API specification is created, a category is also created but is
+  # not deleted when the API specification is deleted. Set this parameter to
+  # true to delete the category when the API specification is deleted.
+  delete_category = true
 }
 
 # Output the ID of the created resource.

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
-module terraform-provider-readme
+module github.com/liveoaklabs/terraform-provider-readme
 
-go 1.20
+go 1.21
 
 require github.com/liveoaklabs/readme-api-go-client v0.1.2
 

--- a/internal/testdata/api_specification.go
+++ b/internal/testdata/api_specification.go
@@ -1,0 +1,135 @@
+package testdata
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/liveoaklabs/readme-api-go-client/readme"
+	"gopkg.in/h2non/gock.v1"
+)
+
+var (
+	APISpecificationResponseBody  = ToJSON(APISpecifications[0])
+	APISpecificationsResponseBody = ToJSON(APISpecifications[0])
+	APISpecificationsNoCategory   = APISpecifications[2]
+
+	APISpecificationDefinition = `{
+			"openapi": "3.0.0",
+			"info": {
+				"version": "1.1.1",
+				"title": "Test API Spec",
+				"license": {
+					"name": "MIT"
+				}
+			}
+		}
+		`
+
+	APISpecificationDefinitionSrc = func() string {
+		escapeQuotes := strings.ReplaceAll(APISpecificationDefinition, `"`, `\"`)
+		escapedNewlines := strings.ReplaceAll(escapeQuotes, "\n", "\\n")
+
+		return escapedNewlines
+	}()
+
+	APIRegistryResponseBodyCreated = `{"registryUUID": "abcdefghijklmno", "definition": ` + APISpecificationDefinition + `}`
+
+	APISpecificationSavedResponse = fmt.Sprintf(
+		"{\"_id\":\"%s\",\"title\":\"%s\"}",
+		APISpecifications[0].ID,
+		APISpecifications[0].Title,
+	)
+)
+
+var APISpecifications = []readme.APISpecification{
+	{
+		ID:         "6398a4a594b26e00885e7ec0",
+		LastSynced: "2022-12-13T16:41:39.512Z",
+		Category: readme.CategorySummary{
+			ID:    "63f8dc63d70452003b73ff12",
+			Title: "Test API Spec",
+			Slug:  "test-api-spec",
+		},
+		Source:  "api",
+		Title:   "Test API Spec",
+		Type:    "oas",
+		Version: "638cf4cfdea3ff0096d1a95a",
+	},
+	{
+		ID:         "6398a4a594b26e00885e7ec1",
+		LastSynced: "2022-12-13T16:40:39.512Z",
+		Category: readme.CategorySummary{
+			ID:    "63f8dc63d70452003b73ff13",
+			Title: "Another Test API Spec",
+			Slug:  "another-test-api-spec",
+		},
+		Source:  "api",
+		Title:   "Another Test API Spec",
+		Type:    "oas",
+		Version: "638cf4cfdea3ff0096d1a95b",
+	},
+	{
+		ID:         "6398a4a594b26e00885e7ec2",
+		LastSynced: "2022-12-13T16:39:39.512Z",
+		Source:     "api",
+		Title:      "Test API Spec Without Category",
+		Type:       "oas",
+		Version:    "638cf4cfdea3ff0096d1a95c",
+	},
+}
+
+func APISpecificationRespond(response any, code int) func() {
+	return func() {
+		gock.OffAll()
+		gock.New(testURL).
+			Get("/api-specification").
+			MatchParam("perPage", "100").
+			MatchParam("page", "1").
+			Persist().
+			Reply(code).
+			SetHeaders(map[string]string{"link": `<>; rel="next", <>; rel="prev", <>; rel="last"`}).
+			JSON(response)
+	}
+}
+
+func APISpecificationCreateRespond(mockVersionList []readme.VersionSummary) func() {
+	return func() {
+		gock.OffAll()
+		// Create in the registry.
+		gock.New(testURL).Post("/api-registry").Times(1).Reply(201).JSON(APIRegistryResponseBodyCreated)
+		gock.New(testURL).Get("/api-registry").Times(1).Reply(200).JSON(APISpecificationDefinition)
+
+		// Create the API spec.
+		gock.New(testURL).Post("/api-specification").Times(1).Reply(201).JSON(APISpecificationSavedResponse)
+
+		// Lookup version
+		gock.New(testURL).Get("/version").Times(1).Reply(200).JSON(mockVersionList)
+		gock.New(testURL).
+			Get("/version" + "/" + mockVersionList[0].VersionClean).
+			Times(1).
+			Reply(200).
+			JSON(mockVersionList[0])
+
+		// Get the created API spec.
+		gock.New(testURL).
+			Get("/api-specification").
+			MatchParam("perPage", "100").
+			MatchParam("page", "1").
+			Persist().
+			Reply(200).
+			SetHeaders(map[string]string{"link": `<>; rel="next", <>; rel="prev", <>; rel="last"`}).
+			JSON(APISpecifications)
+
+		// Delete the API spec.
+		gock.New(testURL).Delete("/api-specification").Times(1).Reply(204)
+	}
+}
+
+func APISpecificationDeleteCategoryRespond(mockVersionList []readme.VersionSummary) func() {
+	return func() {
+		APISpecificationCreateRespond(mockVersionList)()
+
+		// Delete the category.
+		gock.New(testURL).Delete("/categories/" + APISpecifications[0].Category.Slug).Times(1).Reply(204)
+	}
+}

--- a/internal/testdata/testdata.go
+++ b/internal/testdata/testdata.go
@@ -1,0 +1,26 @@
+package testdata
+
+import "encoding/json"
+
+const (
+	// testURL is a dummy URL the provider is configured with and the mock HTTP
+	// service responds to.
+	testURL = "http://testing/api/v1"
+	// testToken is a dummy token the provider is configured with and used
+	// throughout tests.
+	testToken = "hunter2"
+	// providerConfig is a shared configuration that sets a mock url and token.
+	// The URL points to our gock mock server.
+	providerConfig = (`
+		provider "readme" {
+			api_token = "` + testToken + `"
+			api_url   = "` + testURL + `"
+		}
+	`)
+)
+
+func ToJSON(data interface{}) string {
+	bytes, _ := json.Marshal(data)
+
+	return string(bytes)
+}

--- a/main.go
+++ b/main.go
@@ -3,7 +3,8 @@ package main
 import (
 	"context"
 	"log"
-	"terraform-provider-readme/readme"
+
+	"github.com/liveoaklabs/terraform-provider-readme/readme"
 
 	"github.com/hashicorp/terraform-plugin-framework/providerserver"
 )

--- a/readme/api_specification_data_source_test.go
+++ b/readme/api_specification_data_source_test.go
@@ -1,30 +1,19 @@
 package readme
 
 import (
+	"fmt"
 	"regexp"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/liveoaklabs/readme-api-go-client/readme"
+	"github.com/liveoaklabs/terraform-provider-readme/internal/testdata"
 	"gopkg.in/h2non/gock.v1"
 )
 
 func TestAPISpecificationDataSource(t *testing.T) {
 	defer gock.Off()
-
-	// Mock the common API response.
-	testResponse := `[{
-		"id": "6398a4a594b26e00885e7ec0",
-		"lastSynced": "2022-12-13T16:39:39.512Z",
-		"category": {
-			"id": "63f8dc63d70452003b73ff12",
-			"title": "Test API Spec",
-			"slug": "test-api-spec"
-		},
-		"source": "api",
-		"title": "Test API Spec",
-		"type": "oas",
-		"version": "638cf4cfdea3ff0096d1a95a"
-	}]`
+	testResponse := testdata.APISpecifications[:1]
 
 	testCases := []struct {
 		name        string
@@ -34,83 +23,131 @@ func TestAPISpecificationDataSource(t *testing.T) {
 	}{
 		// Unfiltered tests by ID or title.
 		{
-			name:   "it should return an API spec when a matching ID is found",
-			config: `data "readme_api_specification" "test" { id = "6398a4a594b26e00885e7ec0" }`,
+			name: "it should return an API spec when a matching ID is found",
+			config: fmt.Sprintf(
+				`data "readme_api_specification" "test" {
+					id = "%s"
+				}`,
+				testResponse[0].ID,
+			),
 		},
 		{
-			name:   "it should return an API spec when a matching title is found",
-			config: `data "readme_api_specification" "test" { title = "Test API Spec" }`,
+			name: "it should return an API spec when a matching title is found",
+			config: fmt.Sprintf(
+				`data "readme_api_specification" "test" {
+					title = "%s"
+				}`,
+				testResponse[0].Title,
+			),
 		},
 		{
 			name: "it should return an API spec when both a matching ID and title are found",
-			config: `data "readme_api_specification" "test" {
-				id    = "6398a4a594b26e00885e7ec0"
-				title = "Test API Spec"
-			}`,
+			config: fmt.Sprintf(
+				`data "readme_api_specification" "test" {
+					id    = "%s"
+					title = "%s"
+				}`,
+				testResponse[0].ID,
+				testResponse[0].Title,
+			),
 		},
 
 		// Filter tests.
 		{
 			name: "it should return an API spec when a matching title and category ID is found",
-			config: `data "readme_api_specification" "test" {
-				title  = "Test API Spec"
-				filter = { category_id = "63f8dc63d70452003b73ff12" }
-			}`,
+			config: fmt.Sprintf(
+				`data "readme_api_specification" "test" {
+					title  = "%s"
+					filter = { category_id = "%s" }
+				}`,
+				testResponse[0].Title,
+				testResponse[0].Category.ID,
+			),
 		},
 		{
 			name: "it should return an API spec when a matching title and category title is found",
-			config: `data "readme_api_specification" "test" {
-				title  = "Test API Spec"
-				filter = { category_title = "Test API Spec" }
-			}`,
+			config: fmt.Sprintf(
+				`data "readme_api_specification" "test" {
+					title  = "%s"
+					filter = { category_title = "%s" }
+				}`,
+				testResponse[0].Title,
+				testResponse[0].Category.Title,
+			),
 		},
 		{
 			name: "it should return an API spec when a matching title and category slug is found",
-			config: `data "readme_api_specification" "test" {
-				title  = "Test API Spec"
-				filter = { category_slug = "test-api-spec" }
-			}`,
+			config: fmt.Sprintf(
+				`data "readme_api_specification" "test" {
+					title  = "%s"
+					filter = { category_slug = "%s" }
+				}`,
+				testResponse[0].Title,
+				testResponse[0].Category.Slug,
+			),
 		},
 		{
 			name: "it should return an API spec when a matching title, category ID, and category title is found",
-			config: `data "readme_api_specification" "test" {
-				title  = "Test API Spec"
-				filter = {
-					category_id    = "63f8dc63d70452003b73ff12"
-					category_title = "Test API Spec"
-				}
-			}`,
+			config: fmt.Sprintf(
+				`data "readme_api_specification" "test" {
+					title  = "%s"
+					filter = {
+						category_id    = "%s"
+						category_title = "%s"
+					}
+				}`,
+				testResponse[0].Title,
+				testResponse[0].Category.ID,
+				testResponse[0].Category.Title,
+			),
 		},
 		{
 			name: "it should return an API spec when a matching title, category ID, and category slug is found",
-			config: `data "readme_api_specification" "test" {
-				title  = "Test API Spec"
-				filter = {
-					category_id  = "63f8dc63d70452003b73ff12"
-					category_slug = "test-api-spec"
-				}
-			}`,
+			config: fmt.Sprintf(
+				`data "readme_api_specification" "test" {
+					title  = "%s"
+					filter = {
+						category_id   = "%s"
+						category_slug = "%s"
+					}
+				}`,
+				testResponse[0].Title,
+				testResponse[0].Category.ID,
+				testResponse[0].Category.Slug,
+			),
 		},
 		{
 			name: "it should return an API spec when a matching id and category_id is found",
-			config: `data "readme_api_specification" "test" {
-				id     = "6398a4a594b26e00885e7ec0"
-				filter = { category_id = "63f8dc63d70452003b73ff12" }
-			}`,
+			config: fmt.Sprintf(
+				`data "readme_api_specification" "test" {
+					id     = "%s"
+					filter = { category_id = "%s" }
+				}`,
+				testResponse[0].ID,
+				testResponse[0].Category.ID,
+			),
 		},
 		{
 			name: "it should return an API spec when a matching id and category_title is found",
-			config: `data "readme_api_specification" "test" {
-				id     = "6398a4a594b26e00885e7ec0"
-				filter = { category_title = "Test API Spec" }
-			}`,
+			config: fmt.Sprintf(
+				`data "readme_api_specification" "test" {
+					id     = "%s"
+					filter = { category_title = "%s" }
+				}`,
+				testResponse[0].ID,
+				testResponse[0].Category.Title,
+			),
 		},
 		{
 			name: "it should return an API spec when a matching id and category_slug is found",
-			config: `data "readme_api_specification" "test" {
-				id     = "6398a4a594b26e00885e7ec0"
-				filter = { category_slug = "test-api-spec" }
-			}`,
+			config: fmt.Sprintf(
+				`data "readme_api_specification" "test" {
+					id     = "%s"
+					filter = { category_slug = "%s" }
+				}`,
+				testResponse[0].ID,
+				testResponse[0].Category.Slug,
+			),
 		},
 
 		// Negative tests
@@ -141,58 +178,67 @@ func TestAPISpecificationDataSource(t *testing.T) {
 		},
 		{
 			name: "it should return an error when no matching ID and category slug is found",
-			config: `data "readme_api_specification" "test" {
-				id = "6398a4a594b26e00885e7ec0"
-				filter = { category_slug = "does-not-exist" }
-			}`,
+			config: fmt.Sprintf(
+				`data "readme_api_specification" "test" {
+					id     = "%s"
+					filter = { category_slug = "does-not-exist" }
+				}`,
+				testResponse[0].ID,
+			),
 			expectError: "Unable to find API specification with the specified criteria.",
 		},
 		{
 			name: "it should return an error when no matching title and category slug is found",
-			config: `data "readme_api_specification" "test" {
-				title = "Test API Spec"
-				filter = { category_slug = "does-not-exist" }
-			}`,
+			config: fmt.Sprintf(
+				`data "readme_api_specification" "test" {
+					title  = "%s"
+					filter = { category_slug = "does-not-exist" }
+				}`,
+				testResponse[0].Title,
+			),
 			expectError: "Unable to find API specification with title: Test API Spec",
 		},
 		{
 			name: "it should return an error when no matching title and category id is found",
-			config: `data "readme_api_specification" "test" {
-				title = "Test API Spec"
-				filter = { category_id = "does-not-exist" }
-			}`,
+			config: fmt.Sprintf(
+				`data "readme_api_specification" "test" {
+					title  = "%s"
+					filter = { category_id = "does-not-exist" }
+				}`,
+				testResponse[0].Title,
+			),
 			expectError: "Unable to find API specification with title: Test API Spec",
 		},
 		{
 			name: "it should return an error when no matching title and category title is found",
-			config: `data "readme_api_specification" "test" {
-				title = "Test API Spec"
-				filter = { category_title = "does-not-exist" }
-			}`,
+			config: fmt.Sprintf(
+				`data "readme_api_specification" "test" {
+					title  = "%s"
+					filter = { category_title = "does-not-exist" }
+				}`,
+				testResponse[0].Title,
+			),
 			expectError: "Unable to find API specification with title: Test API Spec",
 		},
 		{
 			name: "it should return an error when no matching title with a category is found",
-			config: `data "readme_api_specification" "test" {
-				title = "Test API Spec"
-				filter = { has_category = true }
-			}`,
-			response: `[{
-				"id": "6398a4a594b26e00885e7ec0",
-				"lastSynced": "2022-12-13T16:39:39.512Z",
-				"category": null,
-				"source": "api",
-				"title": "Test API Spec",
-				"type": "oas",
-				"version": "638cf4cfdea3ff0096d1a95a"
-			}]`,
+			config: fmt.Sprintf(
+				`data "readme_api_specification" "test" {
+					title  = "%s"
+					filter = { has_category = false }
+				}`,
+				testResponse[0].Title,
+			),
+			response: testdata.ToJSON(
+				[]readme.APISpecification{testdata.APISpecificationsNoCategory},
+			),
 			expectError: "Unable to find API specification with title: Test API Spec",
 		},
 	}
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			response := testResponse
+			response := testdata.ToJSON(testResponse)
 			if tc.response != "" {
 				response = tc.response
 			}
@@ -205,21 +251,10 @@ func TestAPISpecificationDataSource(t *testing.T) {
 						{
 							Config:      providerConfig + tc.config,
 							ExpectError: regexp.MustCompile(tc.expectError),
-							PreConfig: func() {
-								gock.OffAll()
-								gock.New(testURL).
-									Get("/api-specification").
-									MatchParam("perPage", "100").
-									MatchParam("page", "1").
-									Persist().
-									Reply(200).
-									SetHeaders(map[string]string{"link": `<>; rel="next", <>; rel="prev", <>; rel="last"`}).
-									JSON(response)
-							},
+							PreConfig:   testdata.APISpecificationRespond(response, 200),
 						},
 					},
 				})
-
 			} else {
 				resource.Test(t, resource.TestCase{
 					IsUnitTest:               true,
@@ -231,45 +266,35 @@ func TestAPISpecificationDataSource(t *testing.T) {
 								resource.TestCheckResourceAttr(
 									"data.readme_api_specification.test",
 									"id",
-									"6398a4a594b26e00885e7ec0",
+									testdata.APISpecifications[0].ID,
 								),
 								resource.TestCheckResourceAttr(
 									"data.readme_api_specification.test",
 									"last_synced",
-									"2022-12-13T16:39:39.512Z",
+									testdata.APISpecifications[0].LastSynced,
 								),
 								resource.TestCheckResourceAttr(
 									"data.readme_api_specification.test",
 									"source",
-									"api",
+									testdata.APISpecifications[0].Source,
 								),
 								resource.TestCheckResourceAttr(
 									"data.readme_api_specification.test",
 									"title",
-									"Test API Spec",
+									testdata.APISpecifications[0].Title,
 								),
 								resource.TestCheckResourceAttr(
 									"data.readme_api_specification.test",
 									"type",
-									"oas",
+									testdata.APISpecifications[0].Type,
 								),
 								resource.TestCheckResourceAttr(
 									"data.readme_api_specification.test",
 									"version",
-									"638cf4cfdea3ff0096d1a95a",
+									testdata.APISpecifications[0].Version,
 								),
 							),
-							PreConfig: func() {
-								gock.OffAll()
-								gock.New(testURL).
-									Get("/api-specification").
-									MatchParam("perPage", "100").
-									MatchParam("page", "1").
-									Persist().
-									Reply(200).
-									SetHeaders(map[string]string{"link": `<>; rel="next", <>; rel="prev", <>; rel="last"`}).
-									JSON(response)
-							},
+							PreConfig: testdata.APISpecificationRespond(response, 200),
 						},
 					},
 				})

--- a/readme/api_specification_resource_test.go
+++ b/readme/api_specification_resource_test.go
@@ -1,0 +1,64 @@
+package readme
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/liveoaklabs/terraform-provider-readme/internal/testdata"
+	"gopkg.in/h2non/gock.v1"
+)
+
+// TestAPISpecificationResource_Create is a happy path test for the Create method.
+func TestAPISpecificationResource_Create(t *testing.T) {
+	defer gock.OffAll()
+	resource.Test(t, resource.TestCase{
+		IsUnitTest:               true,
+		ProtoV6ProviderFactories: testProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: providerConfig + fmt.Sprintf(`
+					resource "readme_api_specification" "test" {
+						definition = "%s"
+					}`,
+					testdata.APISpecificationDefinitionSrc,
+				),
+				PreConfig: testdata.APISpecificationCreateRespond(mockVersionList),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("readme_api_specification.test", "id", testdata.APISpecifications[0].ID),
+					resource.TestCheckResourceAttr("readme_api_specification.test", "last_synced", testdata.APISpecifications[0].LastSynced),
+					resource.TestCheckResourceAttr("readme_api_specification.test", "source", testdata.APISpecifications[0].Source),
+					resource.TestCheckResourceAttr("readme_api_specification.test", "title", testdata.APISpecifications[0].Title),
+					resource.TestCheckResourceAttr("readme_api_specification.test", "type", testdata.APISpecifications[0].Type),
+					resource.TestCheckResourceAttr("readme_api_specification.test", "version", testdata.APISpecifications[0].Version),
+				),
+			},
+		},
+	})
+}
+
+// TestAPISpecificationResource_CreateDeleteCategory tests that the
+// delete_category flag deletes the category that's created when the API spec
+// is created.
+func TestAPISpecificationResource_CreateDeleteCategory(t *testing.T) {
+	defer gock.OffAll()
+	resource.Test(t, resource.TestCase{
+		IsUnitTest:               true,
+		ProtoV6ProviderFactories: testProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: providerConfig + fmt.Sprintf(`
+					resource "readme_api_specification" "test" {
+						definition      = "%s"
+						delete_category = true
+					}`,
+					testdata.APISpecificationDefinitionSrc,
+				),
+				PreConfig: testdata.APISpecificationDeleteCategoryRespond(mockVersionList),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("readme_api_specification.test", "id", testdata.APISpecifications[0].ID),
+				),
+			},
+		},
+	})
+}


### PR DESCRIPTION
### Fix: (Optionally) Delete spec category when spec is deleted

* Fix an issue where deleting an API specification didn't also delete
  its category. Add a parameter `delete_category` to the
  `api_specification` resource to enable this. It's not enabled by
  default to be consistent with the API behavior.

### Fix missing spec throws an error

* Fix an issue where an API specification deleted outside the provider
  would cause the Terraform-managed resource to throw an error that the
  API spec doesn't exist. Instead of erroring, trigger the creation of a
  new one.

### Add API Specification Resource tests

* Add basic tests for the API Specification resource.
* Establish an internal 'testdata' package to provide common test data
  functionality and mocks. The API specification tests are updated to
  use this new package with other tests to follow in the future. This is
  to help improve the readability and re-usability of test data and
  setup.

### Maintenance

* Use fully qualified module name
* Bump go.mod go version to 1.21