### PR TITLE
fix: category resource nil reference to API response

### DIFF
--- a/readme/category_resource.go
+++ b/readme/category_resource.go
@@ -260,7 +260,7 @@ func (r *categoryResource) Read(
 		apiRequestOptions(types.StringValue(version)),
 	)
 	if err != nil {
-		if apiResponse.APIErrorResponse.Error == "CATEGORY_NOTFOUND" {
+		if apiResponse != nil && apiResponse.APIErrorResponse.Error == "CATEGORY_NOTFOUND" {
 			resp.State.RemoveResource(ctx)
 
 			return


### PR DESCRIPTION
Fix an issue with the category resource where the API response referenced might be nil.