### PR TITLE
fix: normal error message for spec save

### DIFF
--- a/readme/api_specification_resource.go
+++ b/readme/api_specification_resource.go
@@ -462,8 +462,13 @@ func (r *apiSpecificationResource) save(
 	}
 
 	if err != nil {
-		return apiSpecificationResourceModel{}, fmt.Errorf("unable to save: %+v", apiResponse)
-	}
+		var status int
+		if apiResponse != nil {
+			status = apiResponse.HTTPResponse.StatusCode
+		}
+
+		return apiSpecificationResourceModel{},
+			fmt.Errorf("unable to save: (%d) %+v", status, apiResponse.APIErrorResponse) }
 
 	if response.ID == "" {
 		return apiSpecificationResourceModel{}, fmt.Errorf(

--- a/readme/api_specification_resource.go
+++ b/readme/api_specification_resource.go
@@ -468,7 +468,8 @@ func (r *apiSpecificationResource) save(
 		}
 
 		return apiSpecificationResourceModel{},
-			fmt.Errorf("unable to save: (%d) %+v", status, apiResponse.APIErrorResponse) }
+			fmt.Errorf("unable to save: (%d) %+v", status, apiResponse.APIErrorResponse)
+	}
 
 	if response.ID == "" {
 		return apiSpecificationResourceModel{}, fmt.Errorf(


### PR DESCRIPTION
This cleans up the error message that is received when an API specification fails to save. It was displaying the entire API response, which included some unreadable/useless values. This limits that to the response status code and the specific error response from README.