### PR TITLE
maint: linting

### DIFF
--- a/docs/data-sources/api_specifications.md
+++ b/docs/data-sources/api_specifications.md
@@ -3,12 +3,12 @@
 page_title: "readme_api_specifications Data Source - readme"
 subcategory: ""
 description: |-
-  Retrieve multiple API specifications from ReadMe. The filter attribute may be used to filter API specifications by category ID, category slug, category title, title, version, or whether or not the API specifications have a category. See https://docs.readme.com/main/reference/getapispecification for more information about this API endpoint.
+  Retrieve multiple API specifications from ReadMe. The filter attribute may be used to filter API specifications by category ID, category slug, category title, version, or whether or not the API specifications have a category. See https://docs.readme.com/main/reference/getapispecification for more information about this API endpoint.
 ---
 
 # readme_api_specifications (Data Source)
 
-Retrieve multiple API specifications from ReadMe. The `filter` attribute may be used to filter API specifications by category ID, category slug, category title, title, version, or whether or not the API specifications have a category. See <https://docs.readme.com/main/reference/getapispecification> for more information about this API endpoint.
+Retrieve multiple API specifications from ReadMe. The `filter` attribute may be used to filter API specifications by category ID, category slug, category title, version, or whether or not the API specifications have a category. See <https://docs.readme.com/main/reference/getapispecification> for more information about this API endpoint.
 
 ## Example Usage
 
@@ -73,7 +73,7 @@ data "readme_api_specifications" "filter4" {
 
 ### Optional
 
-- `filter` (Attributes) Filter API specifications by the specified criteria. Ommitting this attribute will return all API specifications. All category filters are 'OR' filters except `has_category`, which works as an 'AND' filter with the other category filters. (see [below for nested schema](#nestedatt--filter))
+- `filter` (Attributes) Filter API specifications by the specified criteria. Omitting this attribute will return all API specifications. All category filters are 'OR' filters except `has_category`, which works as an 'AND' filter with the other category filters. (see [below for nested schema](#nestedatt--filter))
 - `sort_by` (String) Sort the returned API specifications by the specified key.Valid values are `title` or `last_synced`. If unset, API specifications are in the order they were returned by the API.
 
 ### Read-Only

--- a/readme/api_registry_data_source_test.go
+++ b/readme/api_registry_data_source_test.go
@@ -1,3 +1,4 @@
+// nolint:goconst // Intentional repetition of some values for tests.
 package readme
 
 import (

--- a/readme/api_specification_data_source.go
+++ b/readme/api_specification_data_source.go
@@ -74,6 +74,7 @@ func (d *apiSpecificationDataSource) Schema(
 	_ datasource.SchemaRequest,
 	resp *datasource.SchemaResponse,
 ) {
+	// nolint: goconst // Attribute descriptions are reused.
 	resp.Schema = schema.Schema{
 		Description: "Retrieve metadata about an API specification on ReadMe.com\n\n" +
 			"An ID or title must be specified to retrieve an API specification. The `filter` attribute may be used " +
@@ -177,7 +178,7 @@ func (d *apiSpecificationDataSource) Read(
 	)
 
 	// If an ID is specified, use that to retrieve the API specification.
-	if state.ID.ValueString() != "" {
+	if state.ID.ValueString() != "" { // nolint: nestif // TODO: Refactor.
 		// Get API specification by ID.
 		apiSpec, apiResponse, err = d.client.APISpecification.Get(state.ID.ValueString())
 		if err != nil {
@@ -226,6 +227,7 @@ func (d *apiSpecificationDataSource) Read(
 			}
 
 			apiSpec = spec
+
 			break
 		}
 

--- a/readme/api_specification_data_source_test.go
+++ b/readme/api_specification_data_source_test.go
@@ -1,3 +1,4 @@
+// nolint:goconst // Intentional repetition of some values for tests.
 package readme
 
 import (
@@ -236,21 +237,21 @@ func TestAPISpecificationDataSource(t *testing.T) {
 		},
 	}
 
-	for _, tc := range testCases {
-		t.Run(tc.name, func(t *testing.T) {
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
 			response := testdata.ToJSON(testResponse)
-			if tc.response != "" {
-				response = tc.response
+			if testCase.response != "" {
+				response = testCase.response
 			}
 
-			if tc.expectError != "" {
+			if testCase.expectError != "" {
 				resource.Test(t, resource.TestCase{
 					IsUnitTest:               true,
 					ProtoV6ProviderFactories: testProtoV6ProviderFactories,
 					Steps: []resource.TestStep{
 						{
-							Config:      providerConfig + tc.config,
-							ExpectError: regexp.MustCompile(tc.expectError),
+							Config:      providerConfig + testCase.config,
+							ExpectError: regexp.MustCompile(testCase.expectError),
 							PreConfig:   testdata.APISpecificationRespond(response, 200),
 						},
 					},
@@ -261,7 +262,7 @@ func TestAPISpecificationDataSource(t *testing.T) {
 					ProtoV6ProviderFactories: testProtoV6ProviderFactories,
 					Steps: []resource.TestStep{
 						{
-							Config: providerConfig + tc.config,
+							Config: providerConfig + testCase.config,
 							Check: resource.ComposeAggregateTestCheckFunc(
 								resource.TestCheckResourceAttr(
 									"data.readme_api_specification.test",

--- a/readme/api_specification_resource.go
+++ b/readme/api_specification_resource.go
@@ -269,7 +269,7 @@ func (r *apiSpecificationResource) Read(
 	// Determine the version ID of the specification from the state or in the plan.
 	version := ""
 	if plan.Version.ValueString() != "" {
-		version = "id:" + plan.Version.ValueString()
+		version = IDPrefix + plan.Version.ValueString()
 	}
 
 	// Get the spec definition from the API registry if a registry UUID is available in the registry.
@@ -452,11 +452,11 @@ func (r *apiSpecificationResource) save(
 	if action == "update" {
 		response, apiResponse, err = r.client.APISpecification.Update(
 			specID,
-			"uuid:"+registry.RegistryUUID,
+			UUIDPrefix+registry.RegistryUUID,
 		)
 	} else {
 		response, apiResponse, err = r.client.APISpecification.Create(
-			"uuid:"+registry.RegistryUUID,
+			UUIDPrefix+registry.RegistryUUID,
 			requestOptions,
 		)
 	}
@@ -483,7 +483,7 @@ func (r *apiSpecificationResource) save(
 	// Get the spec plan.
 	plan, err = r.makePlan(response.ID, plan.Definition, registry.RegistryUUID, version)
 	if err != nil {
-		return apiSpecificationResourceModel{}, fmt.Errorf("unable to make plan: %+v", err)
+		return apiSpecificationResourceModel{}, fmt.Errorf("unable to make plan: %+w", err)
 	}
 
 	plan.DeleteCategory = deleteCategory
@@ -502,7 +502,7 @@ func (r *apiSpecificationResource) makePlan(
 	definition types.String,
 	registryUUID, version string,
 ) (apiSpecificationResourceModel, error) {
-	if strings.HasPrefix(version, "id:") {
+	if strings.HasPrefix(version, IDPrefix) {
 		versionInfo, _, err := r.client.Version.Get(version)
 		if err != nil {
 			return apiSpecificationResourceModel{}, fmt.Errorf("error resolving version: %w", err)

--- a/readme/api_specification_resource_test.go
+++ b/readme/api_specification_resource_test.go
@@ -1,3 +1,4 @@
+// nolint:goconst // Intentional repetition of some values for tests.
 package readme
 
 import (
@@ -25,12 +26,36 @@ func TestAPISpecificationResource_Create(t *testing.T) {
 				),
 				PreConfig: testdata.APISpecificationCreateRespond(mockVersionList),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					resource.TestCheckResourceAttr("readme_api_specification.test", "id", testdata.APISpecifications[0].ID),
-					resource.TestCheckResourceAttr("readme_api_specification.test", "last_synced", testdata.APISpecifications[0].LastSynced),
-					resource.TestCheckResourceAttr("readme_api_specification.test", "source", testdata.APISpecifications[0].Source),
-					resource.TestCheckResourceAttr("readme_api_specification.test", "title", testdata.APISpecifications[0].Title),
-					resource.TestCheckResourceAttr("readme_api_specification.test", "type", testdata.APISpecifications[0].Type),
-					resource.TestCheckResourceAttr("readme_api_specification.test", "version", testdata.APISpecifications[0].Version),
+					resource.TestCheckResourceAttr(
+						"readme_api_specification.test",
+						"id",
+						testdata.APISpecifications[0].ID,
+					),
+					resource.TestCheckResourceAttr(
+						"readme_api_specification.test",
+						"last_synced",
+						testdata.APISpecifications[0].LastSynced,
+					),
+					resource.TestCheckResourceAttr(
+						"readme_api_specification.test",
+						"source",
+						testdata.APISpecifications[0].Source,
+					),
+					resource.TestCheckResourceAttr(
+						"readme_api_specification.test",
+						"title",
+						testdata.APISpecifications[0].Title,
+					),
+					resource.TestCheckResourceAttr(
+						"readme_api_specification.test",
+						"type",
+						testdata.APISpecifications[0].Type,
+					),
+					resource.TestCheckResourceAttr(
+						"readme_api_specification.test",
+						"version",
+						testdata.APISpecifications[0].Version,
+					),
 				),
 			},
 		},
@@ -56,7 +81,11 @@ func TestAPISpecificationResource_CreateDeleteCategory(t *testing.T) {
 				),
 				PreConfig: testdata.APISpecificationDeleteCategoryRespond(mockVersionList),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					resource.TestCheckResourceAttr("readme_api_specification.test", "id", testdata.APISpecifications[0].ID),
+					resource.TestCheckResourceAttr(
+						"readme_api_specification.test",
+						"id",
+						testdata.APISpecifications[0].ID,
+					),
 				),
 			},
 		},

--- a/readme/api_specifications_data_source.go
+++ b/readme/api_specifications_data_source.go
@@ -85,15 +85,17 @@ func (d *apiSpecificationsDataSource) Schema(
 	_ datasource.SchemaRequest,
 	resp *datasource.SchemaResponse,
 ) {
+	// nolint:goconst // Some attribute descriptions are
+	// repeated across data sources and resources.
 	resp.Schema = schema.Schema{
 		Description: "Retrieve multiple API specifications from ReadMe. " +
 			"The `filter` attribute may be used to filter API specifications by category ID, category slug, category " +
-			"title, title, version, or whether or not the API specifications have a category. " +
+			"title, version, or whether or not the API specifications have a category. " +
 			"See <https://docs.readme.com/main/reference/getapispecification> for more information about this API " +
 			"endpoint.",
 		Attributes: map[string]schema.Attribute{
 			"filter": schema.SingleNestedAttribute{
-				Description: "Filter API specifications by the specified criteria. Ommitting this attribute will " +
+				Description: "Filter API specifications by the specified criteria. Omitting this attribute will " +
 					"return all API specifications. All category filters are 'OR' filters except `has_category`, which " +
 					"works as an 'AND' filter with the other category filters.",
 				Optional: true,
@@ -301,6 +303,7 @@ func specMatchesMultiFilters(
 
 	if !passCategory {
 		tflog.Info(ctx, fmt.Sprintf("Skipping API specification %s due to category visibility.", spec.ID))
+
 		return false
 	}
 
@@ -310,6 +313,7 @@ func specMatchesMultiFilters(
 		filter.CategoryID == nil &&
 		filter.CategorySlug == nil &&
 		filter.CategoryTitle == nil {
+
 		return true
 	}
 
@@ -317,6 +321,7 @@ func specMatchesMultiFilters(
 	for _, title := range filter.Title {
 		if spec.Title == title.ValueString() {
 			tflog.Info(ctx, fmt.Sprintf("API specification %s matched title filter.", spec.Title))
+
 			return true
 		}
 	}
@@ -325,6 +330,7 @@ func specMatchesMultiFilters(
 	for _, version := range filter.Version {
 		if spec.Version == version.ValueString() {
 			tflog.Info(ctx, fmt.Sprintf("API specification %s matched version filter.", spec.Version))
+
 			return true
 		}
 	}
@@ -333,6 +339,7 @@ func specMatchesMultiFilters(
 	for _, categoryID := range filter.CategoryID {
 		if passCategory && spec.Category.ID == categoryID.ValueString() {
 			tflog.Info(ctx, fmt.Sprintf("API specification %s matched category ID filter.", spec.Category.ID))
+
 			return true
 		}
 	}
@@ -341,6 +348,7 @@ func specMatchesMultiFilters(
 	for _, categorySlug := range filter.CategorySlug {
 		if passCategory && spec.Category.Slug == categorySlug.ValueString() {
 			tflog.Info(ctx, fmt.Sprintf("API specification %s matched category slug filter.", spec.Category.Slug))
+
 			return true
 		}
 	}
@@ -354,6 +362,7 @@ func specMatchesMultiFilters(
 					"API specification %s category %s matched category title filter.", spec.Title, spec.Category.Title,
 				),
 			)
+
 			return true
 		}
 	}

--- a/readme/api_specifications_data_source_test.go
+++ b/readme/api_specifications_data_source_test.go
@@ -244,7 +244,7 @@ func TestAPISpecificationsDataSource(t *testing.T) {
 		},
 	}
 
-	for _, tc := range testCases {
+	for _, tc := range testCases { // nolint:varnamelen
 		t.Run(tc.name, func(t *testing.T) {
 			response := testdata.APISpecifications
 			if tc.response != nil {
@@ -310,7 +310,7 @@ func apiSpecificationsChecks(t *testing.T, specs, excluded []readme.APISpecifica
 	}
 
 	// Ensure the specs returned are correct.
-	for i, spec := range specs {
+	for i, spec := range specs { // nolint:varnamelen
 		checks = append(checks, resource.TestCheckResourceAttr(
 			"data.readme_api_specifications.test",
 			fmt.Sprintf("specs.%d.id", i),

--- a/readme/categories_data_source_test.go
+++ b/readme/categories_data_source_test.go
@@ -1,3 +1,4 @@
+// nolint:goconst // Intentional repetition of some values for tests.
 package readme
 
 import (

--- a/readme/category_data_source_test.go
+++ b/readme/category_data_source_test.go
@@ -1,3 +1,4 @@
+// nolint:goconst // Intentional repetition of some values for tests.
 package readme
 
 import (

--- a/readme/category_docs_data_source_test.go
+++ b/readme/category_docs_data_source_test.go
@@ -1,3 +1,4 @@
+// nolint:goconst // Intentional repetition of some values for tests.
 package readme
 
 import (

--- a/readme/category_resource_test.go
+++ b/readme/category_resource_test.go
@@ -1,3 +1,4 @@
+// nolint:goconst // Intentional repetition of some values for tests.
 package readme
 
 import (

--- a/readme/custom_page.go
+++ b/readme/custom_page.go
@@ -72,6 +72,7 @@ func customPageResourceMapToModel(
 	if plan.HTML.IsUnknown() {
 		plan.HTML = types.StringValue("")
 	}
+
 	return customPageResourceModel{
 		Algolia:    docModelAlgoliaValue(page.Algolia),
 		Body:       plan.Body,
@@ -94,6 +95,8 @@ func customPageResourceMapToModel(
 // customPageDataSourceSchema returns the schema for the
 // readme_custom_page and readme_custom_pages data sources.
 func customPageDataSourceSchema() map[string]schema.Attribute {
+	// nolint:goconst // Attribute descriptions are
+	// repeated across resources and data sources.
 	return map[string]schema.Attribute{
 		"title": schema.StringAttribute{
 			Description: "The title of the custom page.",

--- a/readme/custom_page_data_source_test.go
+++ b/readme/custom_page_data_source_test.go
@@ -1,3 +1,4 @@
+// nolint:goconst // Intentional repetition of some values for tests.
 package readme
 
 import (

--- a/readme/custom_page_resource_test.go
+++ b/readme/custom_page_resource_test.go
@@ -1,3 +1,4 @@
+// nolint:goconst // Intentional repetition of some values for tests.
 package readme
 
 import (
@@ -188,7 +189,11 @@ func TestCustomPageResource(t *testing.T) {
 				PreConfig: func() {
 					// Ensure any existing mocks are removed.
 					gock.OffAll()
-					gock.New(testURL).Get("/custompages/" + mockCustomPages[0].Slug).Times(2).Reply(200).JSON(mockCustomPages[0])
+					gock.New(testURL).
+						Get("/custompages/" + mockCustomPages[0].Slug).
+						Times(2).
+						Reply(200).
+						JSON(mockCustomPages[0])
 					gock.New(testURL).Delete("/custompages/" + mockCustomPages[0].Slug).Times(1).Reply(204)
 				},
 			},

--- a/readme/custom_pages_data_source.go
+++ b/readme/custom_pages_data_source.go
@@ -88,7 +88,6 @@ func (d *customPagesDataSource) Configure(
 
 // Schema for the readme_custom_pages data source.
 func (d *customPagesDataSource) Schema(_ context.Context, _ datasource.SchemaRequest, resp *datasource.SchemaResponse) {
-
 	resp.Schema = schema.Schema{
 		Description: "Retrieve custom pages from the ReadMe API.\n\n" +
 			"See <https://docs.readme.com/reference/getcustompages> for more information about the API.",

--- a/readme/custom_pages_data_source_test.go
+++ b/readme/custom_pages_data_source_test.go
@@ -1,3 +1,4 @@
+// nolint:goconst // Intentional repetition of some values for tests.
 package readme
 
 import (

--- a/readme/doc.go
+++ b/readme/doc.go
@@ -157,7 +157,7 @@ func getDoc(
 		)
 
 		category, apiResponse, err := client.Category.Get(
-			"id:"+state.Category.ValueString(),
+			IDPrefix+state.Category.ValueString(),
 			options,
 		)
 		if err != nil {
@@ -177,7 +177,7 @@ func getDoc(
 				),
 			)
 
-			parent, apiResponse, err := client.Doc.Get("id:"+state.ParentDoc.ValueString(), options)
+			parent, apiResponse, err := client.Doc.Get(IDPrefix+state.ParentDoc.ValueString(), options)
 			if err != nil {
 				// failing here
 				return state, apiResponse, errors.New(clientError(err, apiResponse))

--- a/readme/doc_data_source.go
+++ b/readme/doc_data_source.go
@@ -91,6 +91,8 @@ func (d *docDataSource) Schema(
 	_ datasource.SchemaRequest,
 	resp *datasource.SchemaResponse,
 ) {
+	// nolint: goconst // Attribute descriptions are repeated across doc
+	// resources and data sources.
 	resp.Schema = schema.Schema{
 		Description: "Retrieve docs on ReadMe.com\n\n" +
 			"See <https://docs.readme.com/main/reference/getdoc> for more information about this API endpoint.\n\n",

--- a/readme/doc_resource_test.go
+++ b/readme/doc_resource_test.go
@@ -1,3 +1,4 @@
+// nolint:goconst // Intentional repetition of some values for tests.
 package readme
 
 import (

--- a/readme/doc_search_data_source_test.go
+++ b/readme/doc_search_data_source_test.go
@@ -1,3 +1,4 @@
+// nolint:goconst // Intentional repetition of some values for tests.
 package readme
 
 import (

--- a/readme/doc_test.go
+++ b/readme/doc_test.go
@@ -1,3 +1,4 @@
+// nolint:goconst // Intentional repetition of some values for tests.
 package readme
 
 import (
@@ -202,6 +203,7 @@ func docResourceCommonChecks(mock readme.Doc, prefix string) resource.TestCheckF
 	if prefix == "data." {
 		mockDocBodyString = mockDoc.Body
 	}
+
 	return resource.ComposeAggregateTestCheckFunc(
 		resource.TestCheckResourceAttr(
 			prefix+"readme_doc.test",

--- a/readme/project_data_source_test.go
+++ b/readme/project_data_source_test.go
@@ -1,3 +1,4 @@
+//nolint:goconst
 package readme
 
 import (

--- a/readme/provider.go
+++ b/readme/provider.go
@@ -18,6 +18,14 @@ import (
 	"github.com/liveoaklabs/readme-api-go-client/readme"
 )
 
+const (
+	// IDPrefix is the prefix used for ReadMe resource IDs.
+	IDPrefix = "id:"
+
+	// UUIDPrefix is the prefix used for ReadMe UUIDs.
+	UUIDPrefix = "uuid:"
+)
+
 // Ensure the implementation satisfies the expected interfaces
 var _ provider.Provider = &readmeProvider{}
 
@@ -273,7 +281,7 @@ func apiRequestOptions(version basetypes.StringValue) readme.RequestOptions {
 
 // versionClean returns the "clean" version for a version ID.
 func versionClean(ctx context.Context, client *readme.Client, versionID string) string {
-	version, apiResponse, err := client.Version.Get("id:" + versionID)
+	version, apiResponse, err := client.Version.Get(IDPrefix + versionID)
 	if err != nil {
 		tflog.Info(
 			ctx,

--- a/readme/version_data_source.go
+++ b/readme/version_data_source.go
@@ -171,7 +171,7 @@ func (d *versionDataSource) Read(
 	} else if state.Version.ValueString() != "" {
 		reqVersion = state.Version.ValueString()
 	} else if state.ID.ValueString() != "" {
-		reqVersion = "id:" + state.ID.ValueString()
+		reqVersion = IDPrefix + state.ID.ValueString()
 	}
 
 	// Get the version.

--- a/readme/version_data_source_test.go
+++ b/readme/version_data_source_test.go
@@ -1,3 +1,4 @@
+// nolint:goconst // Intentional repetition of some values for tests.
 package readme
 
 import (

--- a/readme/version_resource_test.go
+++ b/readme/version_resource_test.go
@@ -1,3 +1,4 @@
+// nolint:goconst // Intentional repetition of some values for tests.
 package readme
 
 import (
@@ -9,6 +10,8 @@ import (
 	"github.com/liveoaklabs/readme-api-go-client/readme"
 	"gopkg.in/h2non/gock.v1"
 )
+
+const versionEndpoint = "/version"
 
 func TestVersionResource(t *testing.T) {
 	// mockUpdatedVersion is used in the update tests.
@@ -35,17 +38,17 @@ func TestVersionResource(t *testing.T) {
 				PreConfig: func() {
 					// Post-create read and refresh.
 					gock.New(testURL).
-						Get("/version/" + mockVersion.Version).
+						Get(versionEndpoint + "/" + mockVersion.Version).
 						Times(2).
 						Reply(200).
 						JSON(mockVersion)
 					// Create resource.
 					gock.New(testURL).
-						Post("/version").
+						Post(versionEndpoint).
 						Times(1).
 						Reply(200).
 						JSON(mockVersion)
-					gock.New(testURL).Delete("/version/" + mockVersion.Version).Times(5).Reply(200)
+					gock.New(testURL).Delete(versionEndpoint + "/" + mockVersion.Version).Times(5).Reply(200)
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttr(
@@ -120,19 +123,19 @@ func TestVersionResource(t *testing.T) {
 				PreConfig: func() {
 					// Post-update read.
 					gock.New(testURL).
-						Get("/version/" + mockUpdatedVersion.Version).
+						Get(versionEndpoint + "/" + mockUpdatedVersion.Version).
 						Times(2).
 						Reply(200).
 						JSON(mockUpdatedVersion)
 					// Update resource.
 					gock.New(testURL).
-						Put("/version/" + mockVersion.Version).
+						Put(versionEndpoint + "/" + mockVersion.Version).
 						Times(1).
 						Reply(200).
 						JSON(mockUpdatedVersion)
 					// Read current version.
 					gock.New(testURL).
-						Get("/version/" + mockVersion.Version).
+						Get(versionEndpoint + "/" + mockVersion.Version).
 						Times(2).
 						Reply(200).
 						JSON(mockUpdatedVersion)
@@ -178,19 +181,19 @@ func TestVersionResource(t *testing.T) {
 					gock.OffAll()
 					// Expect the provider to read the updated version twice.
 					gock.New(testURL).
-						Get("/version/" + mockUpdatedVersion.Version).
+						Get(versionEndpoint + "/" + mockUpdatedVersion.Version).
 						Times(2).
 						Reply(200).
 						JSON(mockUpdatedVersion)
 					// Expect the replacement to POST a new version.
 					gock.New(testURL).
-						Post("/version").
+						Post(versionEndpoint).
 						Times(1).
 						Reply(200).
 						JSON(mockUpdatedVersion)
 					// Expect the current version to be deleted for replacement.
 					gock.New(testURL).
-						Delete("/version/" + mockUpdatedVersion.Version).
+						Delete(versionEndpoint + "/" + mockUpdatedVersion.Version).
 						Times(1).
 						Reply(200)
 				},
@@ -230,7 +233,7 @@ func TestVersionsResource_Error(t *testing.T) {
 			{
 				PreConfig: func() {
 					gock.New(testURL).
-						Post("/version").
+						Post(versionEndpoint).
 						Times(1).
 						Reply(400).
 						JSON(expectCreateResponse)


### PR DESCRIPTION
Address results of `make lint`:

* Ignore need for constants on repeated values in tests.
* Add a TODO to refactor a couple of blocks of complex logic
* Increase variable name length in some places
* Use constant for IDPrefix and UUIDPrefix
* Shorten line lengths
* Newline before returns