### PR TITLE
fix: Inconsistent results doc

### DIFF
--- a/readme/frontmatter/frontmatter.go
+++ b/readme/frontmatter/frontmatter.go
@@ -24,7 +24,7 @@ type ReadmeFrontMatter struct {
 	Hidden        *bool                 `yaml:"hidden"`                  // changelogs, custom pages, docs
 	HTML          string                `yaml:"html,omitempty"`          // custom page
 	HTMLMode      *bool                 `yaml:"htmlmode"`                // custom page
-	Order         *int                  `yaml:"order"`                   // docs
+	Order         int64                 `yaml:"order"`                   // docs
 	ParentDoc     string                `yaml:"parentDoc,omitempty"`     // docs
 	ParentDocSlug string                `yaml:"parentDocSlug,omitempty"` // docs
 	Title         string                `yaml:"title"`                   // changelogs, custom pages, docs
@@ -66,7 +66,6 @@ func GetValue(ctx context.Context, body, attribute string) (reflect.Value, strin
 	// If the field exists and is empty, return an empty value.
 	if field.IsZero() {
 		tflog.Debug(ctx, fmt.Sprintf("no front matter found for attribute %s", attribute))
-		tflog.Info(ctx, fmt.Sprintf("no front matter found for attribute %s", attribute))
 
 		return reflect.Value{}, ""
 	}

--- a/readme/frontmatter/planmodifier.go
+++ b/readme/frontmatter/planmodifier.go
@@ -117,7 +117,7 @@ func (m FrontMatterModifier) PlanModifyInt64(
 			return
 		}
 		if value != (reflect.Value{}) && value.CanInterface() {
-			resp.PlanValue = types.Int64Value(int64(value.Elem().Int()))
+			resp.PlanValue = types.Int64Value(int64(value.Int()))
 		}
 	}
 }

--- a/readme/otherattributemodifier/bool.go
+++ b/readme/otherattributemodifier/bool.go
@@ -161,13 +161,14 @@ func (m otherBoolChanged) modifyAttribute(ctx context.Context) {
 
 		// If the value from frontmatter is not empty, compare it to the current state.
 		if value != (reflect.Value{}) {
+			fmValue := value.Interface().(*bool)
 			tflog.Debug(ctx, fmt.Sprintf(
-				"%s was found in frontmatter with value %s",
-				m.otherAttribute, value))
+				"%s was found in frontmatter with value %v",
+				m.otherAttribute, *fmValue))
 
 			// If the value from frontmatter is different from the current
 			// plan, mark this attribute as changed.
-			isChanged = value.Interface().(bool) != otherPlanValue.ValueBool()
+			isChanged = *fmValue != otherPlanValue.ValueBool()
 		} else {
 			tflog.Debug(ctx, fmt.Sprintf(
 				"value for %s was not found in frontmatter",
@@ -233,6 +234,8 @@ func (m otherBoolChanged) PlanModifyString(
 	req planmodifier.StringRequest,
 	resp *planmodifier.StringResponse,
 ) {
+	m.req = req
+	m.resp = resp
 	m.modifyAttribute(ctx)
 }
 
@@ -244,6 +247,8 @@ func (m otherBoolChanged) PlanModifyInt64(
 	req planmodifier.Int64Request,
 	resp *planmodifier.Int64Response,
 ) {
+	m.req = req
+	m.resp = resp
 	m.modifyAttribute(ctx)
 }
 
@@ -254,5 +259,7 @@ func (m otherBoolChanged) PlanModifyBool(
 	req planmodifier.BoolRequest,
 	resp *planmodifier.BoolResponse,
 ) {
+	m.req = req
+	m.resp = resp
 	m.modifyAttribute(ctx)
 }

--- a/readme/otherattributemodifier/int64.go
+++ b/readme/otherattributemodifier/int64.go
@@ -114,6 +114,9 @@ func (m otherInt64Changed) loadValues(
 		rDiag.Append(req.Config.GetAttribute(ctx, m.otherAttribute, &configValue)...)
 		rDiag.Append(req.Plan.GetAttribute(ctx, m.otherAttribute, &planValue)...)
 		rDiag.Append(req.Plan.GetAttribute(ctx, path.Root("body"), &bodyPlanValue)...)
+	default:
+		tflog.Error(ctx, fmt.Sprintf(
+			"otherInt64Changed: unknown request type %T", m.req))
 	}
 
 	return configValue, stateValue, planValue, bodyPlanValue, diags
@@ -215,6 +218,8 @@ func (m otherInt64Changed) PlanModifyString(
 	req planmodifier.StringRequest,
 	resp *planmodifier.StringResponse,
 ) {
+	m.req = req
+	m.resp = resp
 	m.modifyAttribute(ctx)
 }
 
@@ -226,6 +231,8 @@ func (m otherInt64Changed) PlanModifyInt64(
 	req planmodifier.Int64Request,
 	resp *planmodifier.Int64Response,
 ) {
+	m.req = req
+	m.resp = resp
 	m.modifyAttribute(ctx)
 }
 
@@ -236,5 +243,7 @@ func (m otherInt64Changed) PlanModifyBool(
 	req planmodifier.BoolRequest,
 	resp *planmodifier.BoolResponse,
 ) {
+	m.req = req
+	m.resp = resp
 	m.modifyAttribute(ctx)
 }


### PR DESCRIPTION
Follow-up to https://github.com/LiveOakLabs/terraform-provider-readme/pull/78, which addressed an issue with docs where an _inconsistent results after apply_ error would present after certain attributes changed. This wasn't working properly for all values because the resource's req/resp objects weren't properly set and there was a conversion inconsistency between `int` and `int64` values.

* Use `int64` for the `order` attribute for consistency
* Ensure `req` and `resp` are properly set on the
  `otherattributemodifier` when calling the modifier method.


* Add tests for setting and changing the `hidden` and `order` attributes
and the behavior with the `otherattributemodifier` and front matter
handling. These attributes are more unique because one's a boolean and
the other an int64, in contrast with the other string types.