### PR TITLE
fix: volatile 'user' attribute on docs

### DIFF
--- a/readme/doc_resource.go
+++ b/readme/doc_resource.go
@@ -791,6 +791,12 @@ func (r *docResource) Schema(
 			"user": schema.StringAttribute{
 				Description: "The ID of the author of the doc in the web editor.",
 				Computed:    true,
+				PlanModifiers: []planmodifier.String{
+					// The user attribute is volatile and may show changes in
+					// the post-apply diff. This effectively triggers it to
+					// refresh whenever the document is updated.
+					otherattributemodifier.StringModifyString(path.Root("updated_at"), "UpdatedAt", true),
+				},
 			},
 			"version": schema.StringAttribute{
 				Description: "The version to create the doc under.",


### PR DESCRIPTION
The 'user' attribute on doc and related resources is a read-only value with the ID of the user that last modified the resource. This includes users working in the web console and the API user used by Terraform. There was a scenario that could cause an inconsistent state after apply because this value changed between the initial read and the post-update refresh. This updates the attribute to be marked for change whenever the 'updated_at' value changes (which is triggered when several other criteria changes).