### PR TITLE
fix: changelog 'type' is optional

### DIFF
--- a/docs/resources/changelog.md
+++ b/docs/resources/changelog.md
@@ -45,7 +45,7 @@ resource "readme_changelog" "example" {
 
 - `hidden` (Boolean) Whether the changelog is hidden. This can alternatively be set using the `hidden` front matter key.
 - `title` (String) __REQUIRED.__ The title of the changelog. This can alternatively be set using the `title` front matter key.
-- `type` (String) __REQUIRED.__ The type of changelog. This can alternatively be set using the `type` front matter key. Valid values: added, fixed, improved, deprecated, removed
+- `type` (String) The type of changelog. This can alternatively be set using the `type` front matter key. Valid values: added, fixed, improved, deprecated, removed
 
 ### Read-Only
 

--- a/readme/changelog_resource.go
+++ b/readme/changelog_resource.go
@@ -182,31 +182,6 @@ func (r changelogResource) ValidateConfig(
 			return
 		}
 	}
-
-	if data.Type.IsNull() {
-		// check front matter for 'type'.
-		typeMatter, diag := frontmatter.GetValue(ctx, data.Body.ValueString(), "Type")
-		if diag != "" {
-			resp.Diagnostics.AddAttributeError(
-				path.Root("type"),
-				"Error checking front matter during validation.",
-				diag,
-			)
-
-			return
-		}
-
-		// Fail if type is not set in front matter or the attribute.
-		if typeMatter == (reflect.Value{}) {
-			resp.Diagnostics.AddAttributeError(
-				path.Root("type"),
-				"Missing required attribute.",
-				"'type' must be set using the attribute or in the body front matter.",
-			)
-
-			return
-		}
-	}
 }
 
 // Create creates the changelog and sets the initial Terraform state.
@@ -417,7 +392,7 @@ func (r *changelogResource) Schema(_ context.Context, _ resource.SchemaRequest, 
 				},
 			},
 			"type": schema.StringAttribute{
-				Description: "__REQUIRED.__ The type of changelog. This can alternatively be set using the `type` front matter key. " +
+				Description: "The type of changelog. This can alternatively be set using the `type` front matter key. " +
 					"Valid values: added, fixed, improved, deprecated, removed",
 				Computed: true,
 				Optional: true,


### PR DESCRIPTION
Make the `type` parameter on the `changelog` resource optional, as it is in the API and web editor.