### PR TITLE
Doc fixes; API specs data source versions fix

### DIFF
--- a/docs/data-sources/api_specifications.md
+++ b/docs/data-sources/api_specifications.md
@@ -91,7 +91,7 @@ Optional:
 - `category_title` (List of String) Return API specifications matching the specified category titles.
 - `has_category` (Boolean) Return only API specifications with a category. This attribute works as an 'AND' filter with the other category filters.
 - `title` (List of String) Return API specifications matching the specified title.
-- `version` (List of String) Return API specifications matching the specified version ID.
+- `version` (List of String) Return API specifications matching the specified versions (e.g. 1.0.0).
 
 
 <a id="nestedatt--specs"></a>
@@ -105,7 +105,7 @@ Read-Only:
 - `source` (String) The creation source of the API specification.
 - `title` (String) The title of the API specification derived from the specification JSON.
 - `type` (String) The type of the API specification.
-- `version` (String) The version of the API specification.
+- `version` (String) The version ID of the API specification.
 
 <a id="nestedatt--specs--category"></a>
 ### Nested Schema for `specs.category`

--- a/docs/resources/doc.md
+++ b/docs/resources/doc.md
@@ -3,21 +3,36 @@
 page_title: "readme_doc Resource - readme"
 subcategory: ""
 description: |-
-  Manage docs on ReadMe.com
-  Docs on ReadMe support setting some attributes using front matter. Resource attributes take precedence over front matter attributes in the provider.
+  Manage docs on ReadMe.com Docs on ReadMe support setting some attributes using front matter.  Resource attributes take precedence over front matter attributes in  the provider.
   Refer to https://docs.readme.com/main/docs/rdme for more information about using front matter in ReadMe docs and custom pages.
   See https://docs.readme.com/main/reference/getdoc for more information about this API endpoint.
+  Doc Slugs
+  Docs in ReadMe are uniquely identified by their slugs. The slug is a URL-friendly string that is generated upon doc creation. By default, this is a normalized version of the doc title. The slug cannot be altered using the API or the Terraform Provider, but can be edited in the ReadMe web UI.
+  This creates challenges when managing docs with Terraform. To address this, the provider supports the use_slug attribute. When set, the provider will attempt to manage an existing doc by its slug. This can also be set in front matter using the slug key.
+  If this attribute is set and the doc does not exist, an error will be returned. This is intended to be set when inheriting management of an existing doc or when customizing the slug after the doc has been created.
+  Note that doc slugs are shared between Guides and API Specification References.
+  The use_slug attribute is expierimental and may result in unexpected behavior.
 ---
 
 # readme_doc (Resource)
 
-Manage docs on ReadMe.com
+Manage docs on ReadMe.com Docs on ReadMe support setting some attributes using front matter.  Resource attributes take precedence over front matter attributes in  the provider. 
 
-Docs on ReadMe support setting some attributes using front matter. Resource attributes take precedence over front matter attributes in the provider.
+ Refer to <https://docs.readme.com/main/docs/rdme> for more information about using front matter in ReadMe docs and custom pages. 
 
-Refer to <https://docs.readme.com/main/docs/rdme> for more information about using front matter in ReadMe docs and custom pages.
+ See <https://docs.readme.com/main/reference/getdoc> for more information about this API endpoint. 
 
-See <https://docs.readme.com/main/reference/getdoc> for more information about this API endpoint.
+ ## Doc Slugs 
+
+ Docs in ReadMe are uniquely identified by their slugs. The slug is a URL-friendly string that is generated upon doc creation. By default, this is a normalized version of the doc title. The slug cannot be altered using the API or the Terraform Provider, but can be edited in the ReadMe web UI. 
+
+ This creates challenges when managing docs with Terraform. To address this, the provider supports the `use_slug` attribute. When set, the provider will attempt to manage an existing doc by its slug. This can also be set in front matter using the `slug` key. 
+
+ If this attribute is set and the doc does not exist, an error will be returned. This is intended to be set when inheriting management of an existing doc or when customizing the slug *after* the doc has been created. 
+
+ Note that doc slugs are shared between Guides and API Specification References. 
+
+ **The `use_slug` attribute is expierimental and may result in unexpected behavior.**
 
 ## Example Usage
 
@@ -73,8 +88,12 @@ resource "readme_doc" "example" {
 - `parent_doc` (String) For a subpage, specify the parent doc ID.This attribute may be set in the body front matter with the `parentDoc` key.The provider cannot verify that a `parent_doc` exists if it is hidden. To use a `parent_doc` ID without verifying, set the `verify_parent_doc` attribute to `false`.
 - `parent_doc_slug` (String) For a subpage, specify the parent doc slug instead of the ID.This attribute may be set in the body front matter with the `parentDocSlug` key.If a value isn't specified but `parent_doc` is, the provider will attempt to populate this value using the `parent_doc` ID unless `verify_parent_doc` is set to `false`.
 - `title` (String) **Required.** The title of the doc.This attribute may optionally be set in the body front matter.
-- `type` (String) **Required.** Type of the doc. The available types all show up under the /docs/ URL path of your docs project (also known as the "guides" section). Can be "basic" (most common), "error" (page desribing an API error), or "link" (page that redirects to an external link).This attribute may optionally be set in the body front matter.
-- `use_slug` (String) **Use with caution!** Create the doc resource by importing an existing doc by its slug. This is non-conventional and should only be used when the slug is known and the doc is not managed by Terraform. This is useful for managing an API specification's doc that gets created automatically by ReadMe. When set, the specified doc will be replaced with the Terraform-managed doc. Changing the value will trigger a re-creation of the doc. If this is set and then unset, a new doc will be created but the existing doc will not be deleted. The existing doc will be orphaned and will not be managed by Terraform. If this is unset and then set, the existing doc will be deleted and the resource will be pointed to the specified doc. In the case of API specification docs, the doc is implicitly deleted when the API specification is deleted.
+- `type` (String) **Required.** Type of the doc. The available types all show up under the /docs/ URL path of your docs project (also known as the "guides" section). Can be "basic" (most common), "error" (page describing an API error), or "link" (page that redirects to an external link).This attribute may optionally be set in the body front matter.
+- `use_slug` (String) **Use with caution!** Create the doc resource by importing an existing doc by its slug. This is non-conventional and should only be used when the slug is known and the doc is not managed by Terraform or when the slug is changed in the web UI. This is useful for managing an API specification's doc that gets created automatically by ReadMe. When set, the specified doc will be replaced with the Terraform-managed doc.
+
+If this is set and then unset, a new doc will be created but the existing doc will not be deleted. The existing doc will be orphaned and will not be managed by Terraform. If this is unset and then set, the existing doc will be deleted and the resource will be pointed to the specified doc. In the case of API specification docs, the doc is implicitly deleted when the API specification is deleted.
+
+This attribute may be set in the body front matter with the `slug` key.
 - `verify_parent_doc` (Boolean) Enables or disables the provider verifying the `parent_doc` exists. When using the `parent_doc` attribute with a hidden parent, the provider is unable to verify if the parent exists. Setting this to `false` will disable this behavior. When `false`, the `parent_doc_slug` value will not be resolved by the provider unless explicitly set. The `parent_doc_slug` attribute may be used as an alternative. Verifying a `parent_doc` by ID does not work if the parent is hidden.
 - `version` (String) The version to create the doc under.
 

--- a/readme/doc.go
+++ b/readme/doc.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"strings"
 
 	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/types"
@@ -74,11 +75,14 @@ func docModelValue(ctx context.Context, doc readme.Doc, model docModel) docModel
 		model.ParentDocSlug = types.StringValue("")
 	}
 
+	bodyClean := strings.TrimSpace(doc.Body)
+	bodyClean = strings.ReplaceAll(bodyClean, `\n`, "\n")
+
 	return docModel{
 		Algolia:         docModelAlgoliaValue(doc.Algolia),
 		API:             docModelAPIValue(doc.API),
 		Body:            model.Body,
-		BodyClean:       types.StringValue(doc.Body),
+		BodyClean:       types.StringValue(bodyClean),
 		BodyHTML:        types.StringValue(doc.BodyHTML),
 		Category:        types.StringValue(doc.Category),
 		CategorySlug:    model.CategorySlug,

--- a/readme/frontmatter/frontmatter.go
+++ b/readme/frontmatter/frontmatter.go
@@ -27,6 +27,7 @@ type ReadmeFrontMatter struct {
 	Order         int64                 `yaml:"order,omitempty"`         // docs
 	ParentDoc     string                `yaml:"parentDoc,omitempty"`     // docs
 	ParentDocSlug string                `yaml:"parentDocSlug,omitempty"` // docs
+	Slug          string                `yaml:"slug,omitempty"`          // docs
 	Title         string                `yaml:"title,omitempty"`         // changelogs, custom pages, docs
 	Type          string                `yaml:"type,omitempty"`          // changelogs, docs
 }


### PR DESCRIPTION
While Doc slugs cannot be set or updated through the API, the provider has a workaround for re-associating a doc in state with a doc in ReadMe when its slug is changed in the web UI.

* `readme_api_specifications` data source: fix version filtering by setting the version in the request options to request specs of a certain ReadMe version
  * BREAKING (we're still v0; will increment minor version): Update the `version` attribute to accept a version number, not ID.
  * This didn't work at all previously, so perhaps not so breaking
* Allow a doc slug to be set in frontmatter to match
  * This enables the attribute to be set when creating docs in a loop
* Don't trigger a re-creation of a doc when the value of the slug is changed.
* Address issue where the `bodyClean` attribute would report a change after apply
* Add a few additional log statements