### PR TITLE
specs: handle deletion when reading version

### DIFF
--- a/readme/api_specification_resource.go
+++ b/readme/api_specification_resource.go
@@ -269,7 +269,7 @@ func (r *apiSpecResource) Read(ctx context.Context, req resource.ReadRequest, re
 		version:      version,
 	})
 	if err != nil {
-		if strings.Contains(err.Error(), "API specification not found") {
+		if strings.Contains(err.Error(), "API specification not found") || strings.Contains(err.Error(), "no match for version ID") {
 			tflog.Warn(ctx, fmt.Sprintf("API specification %s not found. Removing from state.", state.ID.ValueString()))
 			resp.State.RemoveResource(ctx)
 


### PR DESCRIPTION
If a version isn't found when reading an API spec, don't fail but throw a warning and let the user recover (create a new resource or remove from state)